### PR TITLE
Prevent organize imports to move fetch-polyfill.js

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,7 +1,8 @@
 import "./fetch-polyfill.js";
-import * as optionsJs from "./options.js";
+
 import * as core from "@actions/core";
 import * as openai from "chatgpt";
+import * as optionsJs from "./options.js";
 
 // define type to save parentMessageId and conversationId
 export type Ids = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Release Notes**

Prevent `organize imports` from moving `fetch-polyfill.js`. This pull request reorders the imports in `src/bot.ts` to import `fetch-polyfill.js` before `options.js`.
<!-- end of auto-generated comment: release notes by openai -->