### PR TITLE
increase default max files limit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   max_files:
     required: false
     description: 'Max files to review. Less than or equal to 0 means no limit.'
-    default: '40'
+    default: '80'
   temperature:
     required: false
     description: 'Temperature for GPT model'

--- a/dist/index.js
+++ b/dist/index.js
@@ -28712,7 +28712,7 @@ class Options {
     path_filters;
     system_message;
     temperature;
-    constructor(debug, max_files = '40', review_comment_lgtm = false, path_filters = null, system_message = '', temperature = '0.0') {
+    constructor(debug, max_files = '80', review_comment_lgtm = false, path_filters = null, system_message = '', temperature = '0.0') {
         this.debug = debug;
         this.max_files = parseInt(max_files);
         this.review_comment_lgtm = review_comment_lgtm;

--- a/src/options.ts
+++ b/src/options.ts
@@ -149,7 +149,7 @@ export class Options {
 
   constructor(
     debug: boolean,
-    max_files = '40',
+    max_files = '80',
     review_comment_lgtm = false,
     path_filters: string[] | null = null,
     system_message = '',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Release Notes**

This pull request increases the default maximum number of files that can be processed by the software from 40 to 80. This change was made in the `src/options.ts` file. 

- New Feature: Increased default max files limit from 40 to 80.
<!-- end of auto-generated comment: release notes by openai -->