### PR TITLE
limit event to created comments

### DIFF
--- a/.github/workflows/chatgpt-review.yml
+++ b/.github/workflows/chatgpt-review.yml
@@ -28,4 +28,4 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         with:
           debug: true
-          review_comment_lgtm: true
+          review_comment_lgtm: false

--- a/.github/workflows/chatgpt-review.yml
+++ b/.github/workflows/chatgpt-review.yml
@@ -28,4 +28,4 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         with:
           debug: true
-          review_comment_lgtm: false
+          review_comment_lgtm: true

--- a/.github/workflows/chatgpt-review.yml
+++ b/.github/workflows/chatgpt-review.yml
@@ -4,7 +4,10 @@ permissions:
   contents: read
   pull-requests: write
 
-on: [pull_request, pull_request_review_comment]
+on:
+  pull_request:
+  pull_request_review_comment:
+    types: [created]
 
 concurrency:
   group:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ permissions:
   contents: read
   pull-requests: write
 
-on: [pull_request, pull_request_review_comment]
+on:
+  pull_request:
+  pull_request_review_comment:
+    types: [created]
 
 concurrency:
   group:

--- a/dist/index.js
+++ b/dist/index.js
@@ -29148,6 +29148,11 @@ const handleReviewComment = async (bot) => {
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.warning(`Skipped: ${context.eventName} event is missing pull_request`);
         return;
     }
+    // check if the comment was created and not edited or deleted
+    if (context.payload.action !== 'created') {
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.warning(`Skipped: ${context.eventName} event is not created`);
+        return;
+    }
     // Check if the comment is not from the bot itself
     if (!comment.body.includes(_commenter_js__WEBPACK_IMPORTED_MODULE_2__/* .COMMENT_TAG */ .Rs) &&
         !comment.body.includes(_commenter_js__WEBPACK_IMPORTED_MODULE_2__/* .COMMENT_REPLY_TAG */ .aD)) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -27177,7 +27177,7 @@ ${tag}`;
             const conversationChain = reviewComments
                 .filter((cmt) => cmt.in_reply_to_id === topLevelComment.id)
                 .map((cmt) => `${cmt.user.login}-(${cmt.id}): ${cmt.body}`);
-            conversationChain.unshift(`${topLevelComment.user.login}-(${topLevelComment.id}): ${topLevelComment.body}`);
+            conversationChain.unshift(`${topLevelComment.user.login}: ${topLevelComment.body}`);
             return {
                 chain: conversationChain.join('\n---\n'),
                 topLevelComment
@@ -29174,12 +29174,16 @@ Diff:
 ${diffHunk}
 \`\`\`
 
-Conversation chain:
+Conversation chain (including the new comment):
 \`\`\`
 ${chain}
 \`\`\`
 
-Please reply to the latest comment in the conversation chain without extra prose as that reply will be posted as-is.`;
+Please reply to the new comment in the conversation chain without extra prose as that reply will be posted as-is. Make sure to tag the user in your reply. Providing below the new comment again as reference:
+\`\`\`
+${comment.user.login}: ${comment.body}
+\`\`\`
+`;
             const [reply] = await bot.chat(prompt, {});
             const message = `${_commenter_js__WEBPACK_IMPORTED_MODULE_2__/* .COMMENT_GREETING */ .pK}
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -27049,9 +27049,10 @@ class Bot {
 /* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
 /* harmony export */   "Es": () => (/* binding */ Commenter),
 /* harmony export */   "Rs": () => (/* binding */ COMMENT_TAG),
-/* harmony export */   "aD": () => (/* binding */ COMMENT_REPLY_TAG)
+/* harmony export */   "aD": () => (/* binding */ COMMENT_REPLY_TAG),
+/* harmony export */   "pK": () => (/* binding */ COMMENT_GREETING)
 /* harmony export */ });
-/* unused harmony exports COMMENT_GREETING, DESCRIPTION_TAG, DESCRIPTION_TAG_END */
+/* unused harmony exports DESCRIPTION_TAG, DESCRIPTION_TAG_END */
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(2186);
 /* harmony import */ var _actions_github__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(5438);
 /* harmony import */ var _octokit_action__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(1231);
@@ -29177,7 +29178,12 @@ ${chain}
 
 Please reply to the latest comment in the conversation chain without extra prose as that reply will be posted as-is.`;
             const [reply] = await bot.chat(prompt, {});
-            const message = `${_commenter_js__WEBPACK_IMPORTED_MODULE_2__/* .COMMENT_REPLY_TAG */ .aD}\n${reply}`;
+            const message = `${_commenter_js__WEBPACK_IMPORTED_MODULE_2__/* .COMMENT_GREETING */ .pK}
+
+${reply}
+
+${_commenter_js__WEBPACK_IMPORTED_MODULE_2__/* .COMMENT_REPLY_TAG */ .aD}
+`;
             if (topLevelComment) {
                 const topLevelCommentId = topLevelComment.id;
                 try {

--- a/dist/index.js
+++ b/dist/index.js
@@ -29160,6 +29160,7 @@ const handleReviewComment = async (bot) => {
         const pull_number = context.payload.pull_request.number;
         const diffHunk = comment.diff_hunk;
         const { chain, topLevelComment } = await commenter.getConversationChain(pull_number, comment);
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Conversation chain: ${chain}`);
         // check whether this chain contains replies from the bot
         if (chain.includes(_commenter_js__WEBPACK_IMPORTED_MODULE_2__/* .COMMENT_TAG */ .Rs) ||
             chain.includes(_commenter_js__WEBPACK_IMPORTED_MODULE_2__/* .COMMENT_REPLY_TAG */ .aD) ||
@@ -29212,6 +29213,9 @@ ${_commenter_js__WEBPACK_IMPORTED_MODULE_2__/* .COMMENT_REPLY_TAG */ .aD}
                 _actions_core__WEBPACK_IMPORTED_MODULE_0__.warning(`Failed to find the top-level comment to reply to`);
             }
         }
+    }
+    else {
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Skipped: ${context.eventName} event is from the bot itself`);
     }
 };
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -29128,7 +29128,7 @@ const token = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('token')
 const octokit = new _octokit_action__WEBPACK_IMPORTED_MODULE_3__/* .Octokit */ .v({ auth: `token ${token}` });
 const context = _actions_github__WEBPACK_IMPORTED_MODULE_1__.context;
 const repo = context.repo;
-const BOT_INVITE = '@openai';
+const ASK_BOT = '@openai';
 const handleReviewComment = async (bot) => {
     const commenter = new _commenter_js__WEBPACK_IMPORTED_MODULE_2__/* .Commenter */ .Es();
     if (context.eventName !== 'pull_request_review_comment') {
@@ -29162,7 +29162,7 @@ const handleReviewComment = async (bot) => {
         // check whether this chain contains replies from the bot
         if (chain.includes(_commenter_js__WEBPACK_IMPORTED_MODULE_2__/* .COMMENT_TAG */ .Rs) ||
             chain.includes(_commenter_js__WEBPACK_IMPORTED_MODULE_2__/* .COMMENT_REPLY_TAG */ .aD) ||
-            comment.body.startsWith(BOT_INVITE)) {
+            comment.body.startsWith(ASK_BOT)) {
             const prompt = `I would like you to reply to the new comment made on a conversation chain on a code review diff.
 
 Diff:

--- a/dist/index.js
+++ b/dist/index.js
@@ -27176,7 +27176,7 @@ ${tag}`;
                 `${comment.user.login}-(${comment.id}): ${comment.body}`
             ];
             let in_reply_to_id = comment.in_reply_to_id;
-            let topLevelComment;
+            let topLevelComment = comment;
             while (in_reply_to_id) {
                 const parentComment = reviewComments.find((cmt) => cmt.id === in_reply_to_id);
                 if (parentComment) {

--- a/src/commenter.ts
+++ b/src/commenter.ts
@@ -151,7 +151,7 @@ ${tag}`
         .map((cmt: any) => `${cmt.user.login}-(${cmt.id}): ${cmt.body}`)
 
       conversationChain.unshift(
-        `${topLevelComment.user.login}-(${topLevelComment.id}): ${topLevelComment.body}`
+        `${topLevelComment.user.login}: ${topLevelComment.body}`
       )
 
       return {

--- a/src/commenter.ts
+++ b/src/commenter.ts
@@ -141,28 +141,18 @@ ${tag}`
   async getConversationChain(pull_number: number, comment: any) {
     try {
       const reviewComments = await list_review_comments(pull_number)
-      const conversationChain: string[] = [
-        `${comment.user.login}-(${comment.id}): ${comment.body}`
-      ]
+      const topLevelComment = await this.getTopLevelComment(
+        reviewComments,
+        comment
+      )
 
-      let in_reply_to_id = comment.in_reply_to_id
-      let topLevelComment: any = comment
+      const conversationChain = reviewComments
+        .filter((cmt: any) => cmt.in_reply_to_id === topLevelComment.id)
+        .map((cmt: any) => `${cmt.user.login}-(${cmt.id}): ${cmt.body}`)
 
-      while (in_reply_to_id) {
-        const parentComment = reviewComments.find(
-          (cmt: any) => cmt.id === in_reply_to_id
-        )
-
-        if (parentComment) {
-          conversationChain.unshift(
-            `${parentComment.user.login}-(${parentComment.id}): ${parentComment.body}`
-          )
-          in_reply_to_id = parentComment.in_reply_to_id
-          topLevelComment = parentComment
-        } else {
-          break
-        }
-      }
+      conversationChain.unshift(
+        `${topLevelComment.user.login}-(${topLevelComment.id}): ${topLevelComment.body}`
+      )
 
       return {
         chain: conversationChain.join('\n---\n'),
@@ -175,6 +165,24 @@ ${tag}`
         topLevelComment: null
       }
     }
+  }
+
+  async getTopLevelComment(reviewComments: any[], comment: any) {
+    let topLevelComment = comment
+
+    while (topLevelComment.in_reply_to_id) {
+      const parentComment = reviewComments.find(
+        (cmt: any) => cmt.id === topLevelComment.in_reply_to_id
+      )
+
+      if (parentComment) {
+        topLevelComment = parentComment
+      } else {
+        break
+      }
+    }
+
+    return topLevelComment
   }
 }
 

--- a/src/commenter.ts
+++ b/src/commenter.ts
@@ -146,7 +146,7 @@ ${tag}`
       ]
 
       let in_reply_to_id = comment.in_reply_to_id
-      let topLevelComment: any | null
+      let topLevelComment: any = comment
 
       while (in_reply_to_id) {
         const parentComment = reviewComments.find(

--- a/src/review-comment.ts
+++ b/src/review-comment.ts
@@ -2,7 +2,12 @@ import * as core from '@actions/core'
 import * as github from '@actions/github'
 import {Octokit} from '@octokit/action'
 import {Bot} from './bot.js'
-import {Commenter, COMMENT_REPLY_TAG, COMMENT_TAG} from './commenter.js'
+import {
+  Commenter,
+  COMMENT_GREETING,
+  COMMENT_REPLY_TAG,
+  COMMENT_TAG
+} from './commenter.js'
 
 const token = core.getInput('token')
   ? core.getInput('token')
@@ -77,8 +82,12 @@ ${chain}
 Please reply to the latest comment in the conversation chain without extra prose as that reply will be posted as-is.`
 
       const [reply] = await bot.chat(prompt, {})
-      const message = `${COMMENT_REPLY_TAG}\n${reply}`
+      const message = `${COMMENT_GREETING}
 
+${reply}
+
+${COMMENT_REPLY_TAG}
+`
       if (topLevelComment) {
         const topLevelCommentId = topLevelComment.id
         try {

--- a/src/review-comment.ts
+++ b/src/review-comment.ts
@@ -61,6 +61,7 @@ export const handleReviewComment = async (bot: Bot) => {
       pull_number,
       comment
     )
+    core.info(`Conversation chain: ${chain}`)
     // check whether this chain contains replies from the bot
     if (
       chain.includes(COMMENT_TAG) ||

--- a/src/review-comment.ts
+++ b/src/review-comment.ts
@@ -75,12 +75,16 @@ Diff:
 ${diffHunk}
 \`\`\`
 
-Conversation chain:
+Conversation chain (including the new comment):
 \`\`\`
 ${chain}
 \`\`\`
 
-Please reply to the latest comment in the conversation chain without extra prose as that reply will be posted as-is.`
+Please reply to the new comment in the conversation chain without extra prose as that reply will be posted as-is. Make sure to tag the user in your reply. Providing below the new comment again as reference:
+\`\`\`
+${comment.user.login}: ${comment.body}
+\`\`\`
+`
 
       const [reply] = await bot.chat(prompt, {})
       const message = `${COMMENT_GREETING}

--- a/src/review-comment.ts
+++ b/src/review-comment.ts
@@ -38,6 +38,12 @@ export const handleReviewComment = async (bot: Bot) => {
     return
   }
 
+  // check if the comment was created and not edited or deleted
+  if (context.payload.action !== 'created') {
+    core.warning(`Skipped: ${context.eventName} event is not created`)
+    return
+  }
+
   // Check if the comment is not from the bot itself
   if (
     !comment.body.includes(COMMENT_TAG) &&

--- a/src/review-comment.ts
+++ b/src/review-comment.ts
@@ -11,7 +11,7 @@ const token = core.getInput('token')
 const octokit = new Octokit({auth: `token ${token}`})
 const context = github.context
 const repo = context.repo
-const BOT_INVITE = '@openai'
+const ASK_BOT = '@openai'
 
 export const handleReviewComment = async (bot: Bot) => {
   const commenter: Commenter = new Commenter()
@@ -60,7 +60,7 @@ export const handleReviewComment = async (bot: Bot) => {
     if (
       chain.includes(COMMENT_TAG) ||
       chain.includes(COMMENT_REPLY_TAG) ||
-      comment.body.startsWith(BOT_INVITE)
+      comment.body.startsWith(ASK_BOT)
     ) {
       const prompt = `I would like you to reply to the new comment made on a conversation chain on a code review diff.
 

--- a/src/review-comment.ts
+++ b/src/review-comment.ts
@@ -118,5 +118,7 @@ ${COMMENT_REPLY_TAG}
         core.warning(`Failed to find the top-level comment to reply to`)
       }
     }
+  } else {
+    core.info(`Skipped: ${context.eventName} event is from the bot itself`)
   }
 }


### PR DESCRIPTION




















<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Release Notes**

This pull request introduces a new feature that limits the event to created comments only. The changes include adding a new event type "created" to trigger the workflow only when a new pull request review comment is created, updating the pull request event to trigger only on "created" comments, refactoring getConversationChain method to use getTopLevelComment method, adding getTopLevelComment method to get top-level comment of a conversation chain, adding COMMENT_GREETING constant for greeting message, and modifying handleReviewComment function to skip events that are not created and include the new comment in the conversation chain.
<!-- end of auto-generated comment: release notes by openai -->