### PR TITLE
reduce default max_files to 40

### DIFF
--- a/.github/workflows/openai-review.yml
+++ b/.github/workflows/openai-review.yml
@@ -30,5 +30,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         with:
-          debug: false
+          debug: true
           review_comment_lgtm: false

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   max_files:
     required: false
     description: 'Max files to review. Less than or equal to 0 means no limit.'
-    default: '80'
+    default: '40'
   temperature:
     required: false
     description: 'Temperature for GPT model'

--- a/dist/index.js
+++ b/dist/index.js
@@ -29116,7 +29116,7 @@ class Options {
     path_filters;
     system_message;
     temperature;
-    constructor(debug, max_files = '80', review_comment_lgtm = false, path_filters = null, system_message = '', temperature = '0.0') {
+    constructor(debug, max_files = '40', review_comment_lgtm = false, path_filters = null, system_message = '', temperature = '0.0') {
         this.debug = debug;
         this.max_files = parseInt(max_files);
         this.review_comment_lgtm = review_comment_lgtm;

--- a/src/options.ts
+++ b/src/options.ts
@@ -185,7 +185,7 @@ export class Options {
 
   constructor(
     debug: boolean,
-    max_files = '80',
+    max_files = '40',
     review_comment_lgtm = false,
     path_filters: string[] | null = null,
     system_message = '',


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Chore: Reduce default `max_files` from 80 to 40 and set `debug` flag to true in `.github/workflows/openai-review.yml`.
<!-- end of auto-generated comment: release notes by openai -->