### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   max_files:
     required: false
     description: 'Max files to review. Less than or equal to 0 means no limit.'
-    default: '40'
+    default: '60'
   review_comment_lgtm:
     required: false
     description: 'Leave comments even if the patch is LGTM'

--- a/src/options.ts
+++ b/src/options.ts
@@ -205,7 +205,7 @@ export class Options {
 
   constructor(
     debug: boolean,
-    max_files = '40',
+    max_files = '60',
     review_comment_lgtm = false,
     path_filters: string[] | null = null,
     system_message = '',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Chore: Update default value of `max_files` input from 40 to 60 in `action.yml` and corresponding option in `Options` class constructor in `src/options.ts`.
<!-- end of auto-generated comment: release notes by openai -->