### PR TITLE
ignore go.work file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,7 @@ inputs:
       !**/*.ini
       !**/*.mod
       !**/*.sum
+      !**/*.work
       !**/*.json
       !**/*.mmd
       !**/*.svg

--- a/dist/index.js
+++ b/dist/index.js
@@ -6311,8 +6311,7 @@ ${skipped_files_to_summarize.length > 0
         }
         await Promise.all(reviewPromises);
         // comment about skipped files for review and summarize
-        if (skipped_files_to_review.length > 0 ||
-            skipped_files_to_summarize.length > 0) {
+        if (skipped_files_to_review.length > 0) {
             const tag = '<!-- openai-skipped-files -->';
             // make bullet points for skipped files
             const comment = `

--- a/src/review.ts
+++ b/src/review.ts
@@ -444,10 +444,7 @@ ${
     await Promise.all(reviewPromises)
 
     // comment about skipped files for review and summarize
-    if (
-      skipped_files_to_review.length > 0 ||
-      skipped_files_to_summarize.length > 0
-    ) {
+    if (skipped_files_to_review.length > 0) {
       const tag = '<!-- openai-skipped-files -->'
       // make bullet points for skipped files
       const comment = `


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Chore: Update exclusion pattern for files with ".work" extension and simplify logic for skipped files in review.ts.
<!-- end of auto-generated comment: release notes by openai -->