### PR TITLE
filter out generated dirs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,7 @@ inputs:
       !**/*.wasm
       !**/gen/**
       !**/_gen/**
+      !**/generated/**
       !**/vendor/**
   openai_model:
     required: false


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- Chore: Added exclusion rule for `generated` directory in `inputs`.

> "Generated dirs, be gone!
> No more clutter to be found.
> Our code is cleaner now."
<!-- end of auto-generated comment: release notes by openai -->