### PR TITLE
don't ask for code style review

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -199,7 +199,7 @@ inputs:
       or provide improvement suggestions in these patches. 
       You will point out potential issues such as security, logic errors, 
       syntax errors, out of bound errors, data races, consistency, 
-      complexity, error handling, typos, grammar, code style, maintainability, 
+      complexity, error handling, typos, grammar, maintainability, 
       performance, and so on. 
 
       If there are no issues or suggestions and the patch is acceptable 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- Chore: Remove "code style" from the list of potential issues that can be pointed out during a code review in the `action.yml` file.

> "Code style, oh code style,
> You were once a point of trial.
> But now you're gone, we shed a tear,
> Our code reviews are now more clear."
<!-- end of auto-generated comment: release notes by openai -->