### PR TITLE
remove code suggestions for now

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -91,9 +91,7 @@ inputs:
       trained by OpenAI. You have been designed to act as a highly 
       experienced software engineer today. Your main task is to review 
       code and documentation, provide suggestions, and write new code 
-      or documentation when requested. Please ensure that your responses
-      are focused on assisting with code and documentation concerns, 
-      following best practices and industry standards.
+      or documentation when requested.
   summarize_file_diff:
     required: false
     description: 'The prompt for the whole pull request'

--- a/action.yml
+++ b/action.yml
@@ -200,8 +200,8 @@ inputs:
       ---
       <start_line-end_line>:
       <explain why suggestion makes sense>
-      ```suggestion
-      <replacement code that from start_line, with necessary changes>
+      ```diff
+      <suggested diff>
       ```
       ---
       <start_line-end_line>:
@@ -213,11 +213,7 @@ inputs:
 
       You can comment or suggest code changes for the patches and the 
       line ranges provided by you should map to the exact line ranges 
-      provided in the patches. When suggesting a code change, it is 
-      important that you provide the new code that replaces the entire 
-      line range in the patch from the beginning. Partial replacements 
-      are not acceptable, as they will not work with GitHub's code 
-      suggestion feature.
+      provided in the patches. 
 
       Reflect on the provided code at least 3 times to identify any 
       bug risks or provide improvement suggestions in these patches. 
@@ -303,11 +299,10 @@ inputs:
       and provide as fenced code block in markdown.
 
       Any code change suggestion to the diff hunk must be enclosed in fenced code 
-      blocks with the suggestion identifier and the change must completely 
-      replace the diff hunk provided to you from the beginning -
+      blocks with the suggestion identifier -
       <your comment to the user>
-      ```suggestion
-      <change>
+      ```diff
+      <suggested diff>
       ```
 runs:
   using: 'node16'

--- a/src/review.ts
+++ b/src/review.ts
@@ -387,7 +387,11 @@ ${comment_chain}
         const reviewMap = parseOpenAIReview(response, options.debug)
         for (const [, review] of reviewMap) {
           // check for LGTM
-          if (!options.review_comment_lgtm && review.comment.includes('LGTM')) {
+          if (
+            !options.review_comment_lgtm &&
+            (review.comment.includes('LGTM') ||
+              review.comment.includes('looks good to me'))
+          ) {
             continue
           }
           if (!context.payload.pull_request) {


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- New Feature: Users can now suggest code changes without following best practices and industry standards. Partial replacements are no longer restricted, and suggested code changes must be enclosed in fenced code blocks with the suggestion identifier.
- Bug fix: The phrase "looks good to me" has been added as an alternative to "LGTM" for skipping review comments.

> "Code review made easy,
> Best practices no longer sleazy.
> Suggest changes with ease,
> And skip reviews with a breeze."
<!-- end of auto-generated comment: release notes by openai -->