### PR TITLE
comment on sub ranges

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -192,25 +192,26 @@ inputs:
       $patches
 
       Your review must consist of comments in the below format 
-      with a separator between review comments. Any other 
+      with a separator between review comments Any other 
       commentary outside of this format will be ignored and will not 
-      be read by the parser. Make sure to use the line numbers exactly 
-      as provided above -
+      be read by the parser -
       <start_line-end_line>:
       <review>
       ---
-      <start_line-end_line>:
+      <replace_start_line-replace_end_line>:
       <review>
       ```suggestion
-      <replacement code from start_line>
+      <new code from replace_start_line to replace_end_line>
       ```
       ---
       ...
 
-      The replacement code you suggest must not be in the diff format and 
-      must the exact code that will replace existing code from the start_line. 
-      The suggestion must include context lines from diff hunk even if they 
-      are unchanged.
+      Make sure your comments are not outside the line ranges in the changes,
+      though you can comment on sub-line ranges. If you want to suggest code 
+      changes, the replacement code you suggest must not be in the diff format 
+      and must be exact code that will replace existing code between 
+      <replace_start_line> and <replace_end_line> based in line number in the 
+      new file.
 
       Reflect on the provided code at least 3 times to identify any 
       bug risks or provide improvement suggestions in these diff hunks. 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- New Feature: Modify the format of review comments for a GitHub action. The new format allows commenting on sub-line ranges and suggests exact code replacements instead of diff format.

> "Code reviews made easy,
> With sub-line ranges so breezy.
> Exact code replacements suggested,
> Reviewers' feedback now perfected."
<!-- end of auto-generated comment: release notes by openai -->