### PR TITLE
avoid suggestion identifier

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -201,7 +201,12 @@ inputs:
       Make sure <review_start_line> and <review_end_line> for each review 
       must be within line ranges in the changes above. Don't echo back the 
       code provided to you as the line number range is sufficient to map 
-      your comment to the relevant code section in GitHub.
+      your comment to the relevant code section in GitHub. Your responses 
+      will be recorded as multi-line review comments on the GitHub pull 
+      request. Markdown format is preferred for your responses. Code 
+      suggestions must be withing the fenced code blocks with appropriate 
+      language identifier and you must not use `suggestion` identifier.
+
 
       Reflect on the provided code at least 3 times to identify any 
       bug risks or provide improvement suggestions in these diff hunks. 
@@ -214,8 +219,6 @@ inputs:
       as-is, please include "LGTM!" (exact word) in your short 
       review comment.
 
-      Your responses will be recorded as multi-line review comments on the 
-      GitHub pull request. Markdown format is preferred for your responses.
   comment:
     required: false
     description: 'Prompt for comment'


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- Documentation: Guidelines added for code suggestions in GitHub pull request reviews. Suggestions must be within fenced code blocks with appropriate language identifier and should not use the `suggestion` identifier. Markdown format is preferred for responses.

> "Code review guidelines, clear as day,
> Will help us all work better, hooray!"
<!-- end of auto-generated comment: release notes by openai -->