### PR TITLE
change diff format

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -197,8 +197,8 @@ inputs:
 
       Your review must consist of comments in the below format 
       with a separator between review comments. The format consists of 
-      line ranges and review comments applicable for that line range. 
-      Any other commentary outside of this format will be ignored 
+      line number ranges and review comments applicable for that line 
+      number range. Any other commentary outside of this format will be ignored 
       and will not be read by the parser -
 
       <start_line_number_in_new_hunk>-<end_line_number_in_new_hunk>:
@@ -206,9 +206,17 @@ inputs:
       ---
       ...
 
+      Example:
+      1-5:
+      LGTM!
+      ---
+      12-17:
+      Please fix typo.
+      ---
+
       It's important that <start_line_number_in_new_hunk> and 
       <end_line_number_in_new_hunk> for each review must be within 
-      line ranges of new_hunks. Don't echo back the 
+      line number ranges of new_hunks. Don't echo back the 
       code provided to you as the line number range is sufficient to map 
       your comment to the relevant code section (within new_hunks) 
       in GitHub. Your responses will be recorded as multi-line review 

--- a/action.yml
+++ b/action.yml
@@ -210,9 +210,6 @@ inputs:
       1-5:
       LGTM!
       ---
-      12-17:
-      Please fix typo.
-      ---
 
       It's important that <start_line_number_in_new_hunk> and 
       <end_line_number_in_new_hunk> for each review must be within 

--- a/action.yml
+++ b/action.yml
@@ -169,25 +169,20 @@ inputs:
 
       Format for changes and review comments (if any) -
 
-      old_hunk:
-      ```
+      ```old_hunk
       <old code with line numbers>
       ```
-      new_hunk:
-      ```
+      ```new_hunk
       <new code with line numbers>
       ```
-      comment_chain:
-      ```text
+      ```comment_chain
       <existing review comments>
       ```
       ---
-      old_hunk:
-      ```
+      ```old_hunk
       <old code with line numbers>
       ```
-      new_hunk:
-      ```
+      ```new_hunk
       <new code with line numbers>
       ```
       ---

--- a/action.yml
+++ b/action.yml
@@ -217,8 +217,7 @@ inputs:
       performance, and so on. 
 
       If there are no issues or suggestions and the change is acceptable 
-      as-is, please include "LGTM!" (exact word) in your short 
-      review comment.
+      as-is, you must include the word `LGTM!` and make a short review comment.
 
   comment:
     required: false

--- a/action.yml
+++ b/action.yml
@@ -200,6 +200,7 @@ inputs:
       line ranges and review comments applicable for that line range. 
       Any other commentary outside of this format will be ignored 
       and will not be read by the parser -
+
       <start_line_number_new_code>-<end_line_number_new_code>:
       <your review>
       ---

--- a/action.yml
+++ b/action.yml
@@ -168,26 +168,16 @@ inputs:
       ```
 
       Format for changes and review comments (if any) -
-
-
       ```new_hunk
       <new code with line numbers>
       ```
 
       ```old_hunk
-      <old code with line numbers>
+      <old code>
       ```
 
       ```comment_chain
       <existing review comments>
-      ```
-      ---
-      ```new_hunk
-      <new code with line numbers>
-      ```
-
-      ```old_hunk
-      <old code with line numbers>
       ```
       ---
       ...
@@ -200,7 +190,6 @@ inputs:
       line number ranges and review comments applicable for that line 
       number range. Any other commentary outside of this format will be ignored 
       and will not be read by the parser -
-
       <start_line_number_in_new_hunk>-<end_line_number_in_new_hunk>:
       <your review>
       ---

--- a/action.yml
+++ b/action.yml
@@ -177,6 +177,7 @@ inputs:
       ```
       <new code with line numbers>
       ```
+      comment_chain:
       ```text
       <existing review comments>
       ```

--- a/action.yml
+++ b/action.yml
@@ -169,21 +169,25 @@ inputs:
 
       Format for changes and review comments (if any) -
 
-      ```old_hunk
-      <old code with line numbers>
-      ```
+
       ```new_hunk
       <new code with line numbers>
       ```
+
+      ```old_hunk
+      <old code with line numbers>
+      ```
+
       ```comment_chain
       <existing review comments>
       ```
       ---
-      ```old_hunk
-      <old code with line numbers>
-      ```
       ```new_hunk
       <new code with line numbers>
+      ```
+
+      ```old_hunk
+      <old code with line numbers>
       ```
       ---
       ...
@@ -212,14 +216,14 @@ inputs:
       request. Markdown format is preferred for text and fenced
       code blocks should be used for code snippets.
 
-      Provide thorough and thoughtful feedback to identify any  
-      bug risks or provide improvement suggestions in these diff hunks. 
+      Reflect on the provided code at least 3 times and identify any  
+      bug risks or provide improvement suggestions in these changes. 
       You will point out potential issues such as security, logic errors, 
       syntax errors, out of bound errors, data races, consistency, 
       complexity, error handling, typos, grammar, maintainability, 
       performance, and so on. 
 
-      If there are no issues or suggestions and the diff hunk is acceptable 
+      If there are no issues or suggestions and the change is acceptable 
       as-is, please include "LGTM!" (exact word) in your short 
       review comment.
 

--- a/action.yml
+++ b/action.yml
@@ -161,29 +161,36 @@ inputs:
       $summary
       ```
 
-      Here is the content of file `$filename` -
+      Here is the content of file `$filename` with 
+      line numbers -
       ```
       $file_content
       ```
 
-      Format for changes and review comments (if any) 
-      on line ranges (line numbers in new file) -
-      <start_line-end_line>: 
-      ```diff
-      <diff_hunk>
+      Format for changes and review comments (if any) -
+
+      old_hunk:
+      ```
+      <old code with line numbers>
+      ```
+      new_hunk:
+      ```
+      <new code with line numbers>
       ```
       ```text
       <existing review comments>
       ```
       ---
-      <start_line-end_line>: 
-      ```diff
-      <diff_hunk>
+      old_hunk:
+      ```
+      <old code with line numbers>
+      ```
+      new_hunk:
+      ```
+      <new code with line numbers>
       ```
       ---
       ...
-
-      The <diff_hunk> is in the unidiff format.
 
       Changes for review -
       $patches
@@ -193,13 +200,15 @@ inputs:
       line ranges and review comments applicable for that line range. 
       Any other commentary outside of this format will be ignored 
       and will not be read by the parser -
-      <review_start_line-review_end_line>:
+      <start_line_number_new_code>-<end_line_number_new_code>:
       <your review>
       ---
       ...
 
-      Make sure <review_start_line> and <review_end_line> for each review 
-      must be within line ranges in the changes above. Don't echo back the 
+      It's important that <start_line_number_new_code> and 
+      <end_line_number_new_code> for each review must be within 
+      line ranges of new hunks as you cannot make comments 
+      on line numbers of old hunks. Don't echo back the 
       code provided to you as the line number range is sufficient to map 
       your comment to the relevant code section in GitHub. Your responses 
       will be recorded as multi-line review comments on the GitHub pull 

--- a/action.yml
+++ b/action.yml
@@ -201,20 +201,19 @@ inputs:
       Any other commentary outside of this format will be ignored 
       and will not be read by the parser -
 
-      <start_line_number_new_code>-<end_line_number_new_code>:
+      <start_line_number_in_new_hunk>-<end_line_number_in_new_hunk>:
       <your review>
       ---
       ...
 
-      It's important that <start_line_number_new_code> and 
-      <end_line_number_new_code> for each review must be within 
-      line ranges of new_hunks as you cannot make comments 
-      on line numbers of old_hunks. Don't echo back the 
+      It's important that <start_line_number_in_new_hunk> and 
+      <end_line_number_in_new_hunk> for each review must be within 
+      line ranges of new_hunks. Don't echo back the 
       code provided to you as the line number range is sufficient to map 
-      your comment to the relevant code section in GitHub. Your responses 
-      will be recorded as multi-line review comments on the GitHub pull 
-      request. Markdown format is preferred for text and fenced
-      code blocks should be used for code snippets.
+      your comment to the relevant code section (within new_hunks) 
+      in GitHub. Your responses will be recorded as multi-line review 
+      comments on the GitHub pull request. Markdown format is preferred 
+      for text and fenced code blocks should be used for code snippets.
 
       Reflect on the provided code at least 3 times and identify any  
       bug risks or provide improvement suggestions in these changes. 

--- a/action.yml
+++ b/action.yml
@@ -207,8 +207,8 @@ inputs:
 
       It's important that <start_line_number_new_code> and 
       <end_line_number_new_code> for each review must be within 
-      line ranges of new hunks as you cannot make comments 
-      on line numbers of old hunks. Don't echo back the 
+      line ranges of new_hunks as you cannot make comments 
+      on line numbers of old_hunks. Don't echo back the 
       code provided to you as the line number range is sufficient to map 
       your comment to the relevant code section in GitHub. Your responses 
       will be recorded as multi-line review comments on the GitHub pull 

--- a/dist/index.js
+++ b/dist/index.js
@@ -4941,12 +4941,10 @@ const codeReview = async (lightBot, heavyBot, options, prompts) => {
             if (!hunks) {
                 continue;
             }
-            const hunks_str = `old_hunk:
-\`\`\`
+            const hunks_str = `\`\`\`old_hunk
 ${hunks.old_hunk}
 \`\`\`
-new_hunk:
-\`\`\`
+\`\`\`new_hunk
 ${hunks.new_hunk}
 \`\`\`
 `;
@@ -5099,7 +5097,6 @@ ${skipped_files_to_summarize.length > 0
 `;
                     line_number += 1;
                 }
-                core.info(`file_content: ${file_content}`);
                 const file_content_tokens = tokenizer/* get_token_count */.u(file_content);
                 if (file_content_tokens < options.heavy_token_limits.extra_content_tokens) {
                     ins.file_content = file_content;
@@ -5123,6 +5120,7 @@ ${skipped_files_to_summarize.length > 0
                     else {
                         comment_chain = '';
                     }
+                    core.info(`comment_chain: ${comment_chain}`);
                     // check comment_chain tokens and skip if too long
                     const comment_chain_tokens = tokenizer/* get_token_count */.u(comment_chain);
                     if (comment_chain_tokens >
@@ -5141,8 +5139,7 @@ ${patch}
 `;
                 if (comment_chain !== '') {
                     ins.patches += `
-comment_chain:
-\`\`\`text
+\`\`\`comment_chain
 ${comment_chain}
 \`\`\`
 `;

--- a/dist/index.js
+++ b/dist/index.js
@@ -5121,7 +5121,6 @@ ${skipped_files_to_summarize.length > 0
                     else {
                         comment_chain = '';
                     }
-                    core.info(`comment_chain: ${comment_chain}`);
                     // check comment_chain tokens and skip if too long
                     const comment_chain_tokens = tokenizer/* get_token_count */.u(comment_chain);
                     if (comment_chain_tokens >

--- a/dist/index.js
+++ b/dist/index.js
@@ -2506,6 +2506,11 @@ ${COMMENT_REPLY_TAG}
     }
     async get_comments_at_range(pull_number, path, start_line, end_line) {
         const comments = await this.list_review_comments(pull_number);
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Range provided: ${path}:${start_line}-${end_line}`);
+        // print each comment that was found and it's start_line and end_line
+        for (const comment of comments) {
+            _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Comment found: ${comment.path}:${comment.start_line}-${comment.end_line}`);
+        }
         return comments.filter((comment) => comment.path === path &&
             comment.start_line >= start_line &&
             comment.line <= end_line &&
@@ -2592,7 +2597,6 @@ ${chain}
                     break;
                 }
             }
-            _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Found Comments: ${all_comments.length}. Comments are: ${all_comments}`);
             this.reviewCommentsCache[target] = all_comments;
             return all_comments;
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -5103,6 +5103,7 @@ ${skipped_files_to_summarize.length > 0
                         line_number += 1;
                     }
                     ins.file_content = file_content;
+                    core.info(`file_content: ${file_content}`);
                 }
                 else {
                     core.info(`skip sending content of file: ${ins.filename} due to token count: ${file_content_tokens}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -4945,7 +4945,6 @@ const codeReview = async (lightBot, heavyBot, options, prompts) => {
 \`\`\`
 ${hunks.old_hunk}
 \`\`\`
----
 new_hunk:
 \`\`\`
 ${hunks.new_hunk}
@@ -5142,6 +5141,7 @@ ${patch}
 `;
                 if (comment_chain !== '') {
                     ins.patches += `
+comment_chain:
 \`\`\`text
 ${comment_chain}
 \`\`\`

--- a/dist/index.js
+++ b/dist/index.js
@@ -5262,7 +5262,7 @@ const parse_patch = (patch) => {
     if (lines[lines.length - 1] === '') {
         lines.pop();
     }
-    lines.forEach(line => {
+    for (const line of lines) {
         if (line.startsWith('-')) {
             old_hunk_lines.push(`${line.substring(1)}`);
             //old_line++
@@ -5277,7 +5277,7 @@ const parse_patch = (patch) => {
             //old_line++
             new_line++;
         }
-    });
+    }
     return {
         old_hunk: old_hunk_lines.join('\n'),
         new_hunk: new_hunk_lines.join('\n')

--- a/dist/index.js
+++ b/dist/index.js
@@ -2592,6 +2592,7 @@ ${chain}
                     break;
                 }
             }
+            _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Found Comments: ${all_comments.length}. Comments are: ${all_comments}`);
             this.reviewCommentsCache[target] = all_comments;
             return all_comments;
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -4941,12 +4941,12 @@ const codeReview = async (lightBot, heavyBot, options, prompts) => {
             if (!hunks) {
                 continue;
             }
-            const hunks_str = `old hunk:
+            const hunks_str = `old_hunk:
 \`\`\`
 ${hunks.old_hunk}
 \`\`\`
 ---
-new hunk:
+new_hunk:
 \`\`\`
 ${hunks.new_hunk}
 \`\`\`

--- a/dist/index.js
+++ b/dist/index.js
@@ -5171,10 +5171,10 @@ ${comment_chain}
         };
         const reviewPromises = [];
         const skipped_files_to_review = [];
-        for (const [filename, file_content, , hunks] of files_to_review) {
+        for (const [filename, file_content, , patches] of files_to_review) {
             if (options.max_files_to_review <= 0 ||
                 reviewPromises.length < options.max_files_to_review) {
-                reviewPromises.push(openai_concurrency_limit(async () => do_review(filename, file_content, hunks)));
+                reviewPromises.push(openai_concurrency_limit(async () => do_review(filename, file_content, patches)));
             }
             else {
                 skipped_files_to_review.push(filename);
@@ -5255,7 +5255,7 @@ const parse_hunk = (hunk) => {
     }
     const old_hunk_lines = [];
     const new_hunk_lines = [];
-    let old_line = hunkInfo.old_hunk.start_line;
+    //let old_line = hunkInfo.old_hunk.start_line
     let new_line = hunkInfo.new_hunk.start_line;
     const lines = hunk.split('\n').slice(1); // Skip the @@ line
     // Remove the last line if it's empty
@@ -5265,7 +5265,7 @@ const parse_hunk = (hunk) => {
     lines.forEach(line => {
         if (line.startsWith('-')) {
             old_hunk_lines.push(`${line.substring(1)}`);
-            old_line++;
+            //old_line++
         }
         else if (line.startsWith('+')) {
             new_hunk_lines.push(`${new_line}: ${line.substring(1)}`);
@@ -5274,7 +5274,7 @@ const parse_hunk = (hunk) => {
         else {
             old_hunk_lines.push(`${line}`);
             new_hunk_lines.push(`${new_line}: ${line}`);
-            old_line++;
+            //old_line++
             new_line++;
         }
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -4939,7 +4939,7 @@ const codeReview = async (lightBot, heavyBot, options, prompts) => {
             if (!patch_lines) {
                 continue;
             }
-            const hunks = parse_hunk(patch);
+            const hunks = parse_patch(patch);
             if (!hunks) {
                 continue;
             }
@@ -5248,8 +5248,8 @@ const patch_start_end_line = (patch) => {
         return null;
     }
 };
-const parse_hunk = (hunk) => {
-    const hunkInfo = patch_start_end_line(hunk);
+const parse_patch = (patch) => {
+    const hunkInfo = patch_start_end_line(patch);
     if (!hunkInfo) {
         return null;
     }
@@ -5257,7 +5257,7 @@ const parse_hunk = (hunk) => {
     const new_hunk_lines = [];
     //let old_line = hunkInfo.old_hunk.start_line
     let new_line = hunkInfo.new_hunk.start_line;
-    const lines = hunk.split('\n').slice(1); // Skip the @@ line
+    const lines = patch.split('\n').slice(1); // Skip the @@ line
     // Remove the last line if it's empty
     if (lines[lines.length - 1] === '') {
         lines.pop();

--- a/dist/index.js
+++ b/dist/index.js
@@ -4335,7 +4335,7 @@ class Inputs {
     filename;
     file_content;
     file_diff;
-    hunks;
+    patches;
     diff;
     comment_chain;
     comment;
@@ -4347,13 +4347,13 @@ class Inputs {
         this.filename = filename;
         this.file_content = file_content;
         this.file_diff = file_diff;
-        this.hunks = patches;
+        this.patches = patches;
         this.diff = diff;
         this.comment_chain = comment_chain;
         this.comment = comment;
     }
     clone() {
-        return new Inputs(this.system_message, this.title, this.description, this.summary, this.filename, this.file_content, this.file_diff, this.hunks, this.diff, this.comment_chain, this.comment);
+        return new Inputs(this.system_message, this.title, this.description, this.summary, this.filename, this.file_content, this.file_diff, this.patches, this.diff, this.comment_chain, this.comment);
     }
     render(content) {
         if (!content) {
@@ -4380,8 +4380,8 @@ class Inputs {
         if (this.file_diff) {
             content = content.replace('$file_diff', this.file_diff);
         }
-        if (this.hunks) {
-            content = content.replace('$patches', this.hunks);
+        if (this.patches) {
+            content = content.replace('$patches', this.patches);
         }
         if (this.diff) {
             content = content.replace('$diff', this.diff);
@@ -5134,17 +5134,17 @@ ${skipped_files_to_summarize.length > 0
                         core.warning(`Failed to get comments: ${e}, skipping. backtrace: ${e.stack}`);
                     }
                 }
-                ins.hunks += `
+                ins.patches += `
 ${patch}
 `;
                 if (comment_chain !== '') {
-                    ins.hunks += `
+                    ins.patches += `
 \`\`\`comment_chain
 ${comment_chain}
 \`\`\`
 `;
                 }
-                ins.hunks += `
+                ins.patches += `
 ---
 `;
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -2506,15 +2506,12 @@ ${COMMENT_REPLY_TAG}
     }
     async get_comments_at_range(pull_number, path, start_line, end_line) {
         const comments = await this.list_review_comments(pull_number);
-        _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Range provided: ${path}:${start_line}-${end_line}`);
-        // print each comment that was found and it's start_line and end_line
-        for (const comment of comments) {
-            _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Comment found: ${comment.path}:${comment.start_line}-${comment.end_line}`);
-        }
         return comments.filter((comment) => comment.path === path &&
-            comment.start_line >= start_line &&
-            comment.line <= end_line &&
-            comment.body !== '');
+            comment.body !== '' &&
+            ((comment.start_line &&
+                comment.start_line >= start_line &&
+                comment.line <= end_line) ||
+                comment.line === end_line));
     }
     async get_conversation_chains_at_range(pull_number, path, start_line, end_line, tag = '') {
         const existing_comments = await this.get_comments_at_range(pull_number, path, start_line, end_line);

--- a/dist/index.js
+++ b/dist/index.js
@@ -5092,14 +5092,6 @@ ${skipped_files_to_summarize.length > 0
             const ins = inputs.clone();
             ins.filename = filename;
             if (file_content.length > 0) {
-                const lines = file_content.split('\n');
-                let line_number = 1;
-                file_content = '';
-                for (const line of lines) {
-                    file_content += `${line_number}: ${line}
-`;
-                    line_number += 1;
-                }
                 const file_content_tokens = tokenizer/* get_token_count */.u(file_content);
                 if (file_content_tokens < options.heavy_token_limits.extra_content_tokens) {
                     ins.file_content = file_content;
@@ -5272,7 +5264,7 @@ const parse_hunk = (hunk) => {
     }
     lines.forEach(line => {
         if (line.startsWith('-')) {
-            old_hunk_lines.push(`${old_line}: ${line.substring(1)}`);
+            old_hunk_lines.push(`${line.substring(1)}`);
             old_line++;
         }
         else if (line.startsWith('+')) {
@@ -5280,7 +5272,7 @@ const parse_hunk = (hunk) => {
             new_line++;
         }
         else {
-            old_hunk_lines.push(`${old_line}: ${line}`);
+            old_hunk_lines.push(`${line}`);
             new_hunk_lines.push(`${new_line}: ${line}`);
             old_line++;
             new_line++;

--- a/src/commenter.ts
+++ b/src/commenter.ts
@@ -252,19 +252,14 @@ ${COMMENT_REPLY_TAG}
     end_line: number
   ) {
     const comments = await this.list_review_comments(pull_number)
-    core.info(`Range provided: ${path}:${start_line}-${end_line}`)
-    // print each comment that was found and it's start_line and end_line
-    for (const comment of comments) {
-      core.info(
-        `Comment found: ${comment.path}:${comment.start_line}-${comment.end_line}`
-      )
-    }
     return comments.filter(
       (comment: any) =>
         comment.path === path &&
-        comment.start_line >= start_line &&
-        comment.line <= end_line &&
-        comment.body !== ''
+        comment.body !== '' &&
+        ((comment.start_line &&
+          comment.start_line >= start_line &&
+          comment.line <= end_line) ||
+          comment.line === end_line)
     )
   }
 

--- a/src/commenter.ts
+++ b/src/commenter.ts
@@ -252,6 +252,13 @@ ${COMMENT_REPLY_TAG}
     end_line: number
   ) {
     const comments = await this.list_review_comments(pull_number)
+    core.info(`Range provided: ${path}:${start_line}-${end_line}`)
+    // print each comment that was found and it's start_line and end_line
+    for (const comment of comments) {
+      core.info(
+        `Comment found: ${comment.path}:${comment.start_line}-${comment.end_line}`
+      )
+    }
     return comments.filter(
       (comment: any) =>
         comment.path === path &&
@@ -379,9 +386,6 @@ ${chain}
           break
         }
       }
-      core.info(
-        `Found Comments: ${all_comments.length}. Comments are: ${all_comments}`
-      )
 
       this.reviewCommentsCache[target] = all_comments
       return all_comments

--- a/src/commenter.ts
+++ b/src/commenter.ts
@@ -253,8 +253,8 @@ ${COMMENT_REPLY_TAG}
     return comments.filter(
       (comment: any) =>
         comment.path === path &&
-        comment.start_line === start_line &&
-        comment.line === end_line &&
+        comment.start_line >= start_line &&
+        comment.line <= end_line &&
         comment.body !== ''
     )
   }

--- a/src/commenter.ts
+++ b/src/commenter.ts
@@ -171,7 +171,7 @@ ${tag}`
 
       if (!found) {
         core.info(
-          `Creating new review comment for ${path}:${end_line}: ${message}`
+          `Creating new review comment for ${path}:${start_line}-${end_line}: ${message}`
         )
         await octokit.pulls.createReviewComment({
           owner: repo.owner,
@@ -186,7 +186,9 @@ ${tag}`
         })
       }
     } catch (e) {
-      core.warning(`Failed to post review comment: ${e}`)
+      core.warning(
+        `Failed to post review comment, for ${path}:${start_line}-${end_line}: ${e}`
+      )
     }
   }
 

--- a/src/commenter.ts
+++ b/src/commenter.ts
@@ -379,6 +379,9 @@ ${chain}
           break
         }
       }
+      core.info(
+        `Found Comments: ${all_comments.length}. Comments are: ${all_comments}`
+      )
 
       this.reviewCommentsCache[target] = all_comments
       return all_comments

--- a/src/options.ts
+++ b/src/options.ts
@@ -51,7 +51,7 @@ export class Inputs {
   filename: string
   file_content: string
   file_diff: string
-  hunks: string
+  patches: string
   diff: string
   comment_chain: string
   comment: string
@@ -76,7 +76,7 @@ export class Inputs {
     this.filename = filename
     this.file_content = file_content
     this.file_diff = file_diff
-    this.hunks = patches
+    this.patches = patches
     this.diff = diff
     this.comment_chain = comment_chain
     this.comment = comment
@@ -91,7 +91,7 @@ export class Inputs {
       this.filename,
       this.file_content,
       this.file_diff,
-      this.hunks,
+      this.patches,
       this.diff,
       this.comment_chain,
       this.comment
@@ -123,8 +123,8 @@ export class Inputs {
     if (this.file_diff) {
       content = content.replace('$file_diff', this.file_diff)
     }
-    if (this.hunks) {
-      content = content.replace('$patches', this.hunks)
+    if (this.patches) {
+      content = content.replace('$patches', this.patches)
     }
     if (this.diff) {
       content = content.replace('$diff', this.diff)

--- a/src/options.ts
+++ b/src/options.ts
@@ -51,7 +51,7 @@ export class Inputs {
   filename: string
   file_content: string
   file_diff: string
-  patches: string
+  hunks: string
   diff: string
   comment_chain: string
   comment: string
@@ -76,7 +76,7 @@ export class Inputs {
     this.filename = filename
     this.file_content = file_content
     this.file_diff = file_diff
-    this.patches = patches
+    this.hunks = patches
     this.diff = diff
     this.comment_chain = comment_chain
     this.comment = comment
@@ -91,7 +91,7 @@ export class Inputs {
       this.filename,
       this.file_content,
       this.file_diff,
-      this.patches,
+      this.hunks,
       this.diff,
       this.comment_chain,
       this.comment
@@ -123,8 +123,8 @@ export class Inputs {
     if (this.file_diff) {
       content = content.replace('$file_diff', this.file_diff)
     }
-    if (this.patches) {
-      content = content.replace('$patches', this.patches)
+    if (this.hunks) {
+      content = content.replace('$patches', this.hunks)
     }
     if (this.diff) {
       content = content.replace('$diff', this.diff)

--- a/src/review.ts
+++ b/src/review.ts
@@ -127,12 +127,10 @@ export const codeReview = async (
         if (!hunks) {
           continue
         }
-        const hunks_str = `old_hunk:
-\`\`\`
+        const hunks_str = `\`\`\`old_hunk
 ${hunks.old_hunk}
 \`\`\`
-new_hunk:
-\`\`\`
+\`\`\`new_hunk
 ${hunks.new_hunk}
 \`\`\`
 `
@@ -337,7 +335,6 @@ ${
 `
           line_number += 1
         }
-        core.info(`file_content: ${file_content}`)
         const file_content_tokens = tokenizer.get_token_count(file_content)
         if (
           file_content_tokens < options.heavy_token_limits.extra_content_tokens
@@ -371,6 +368,7 @@ ${
           } else {
             comment_chain = ''
           }
+          core.info(`comment_chain: ${comment_chain}`)
           // check comment_chain tokens and skip if too long
           const comment_chain_tokens = tokenizer.get_token_count(comment_chain)
           if (
@@ -394,8 +392,7 @@ ${patch}
 `
         if (comment_chain !== '') {
           ins.patches += `
-comment_chain:
-\`\`\`text
+\`\`\`comment_chain
 ${comment_chain}
 \`\`\`
 `

--- a/src/review.ts
+++ b/src/review.ts
@@ -343,6 +343,7 @@ ${
             line_number += 1
           }
           ins.file_content = file_content
+          core.info(`file_content: ${file_content}`)
         } else {
           core.info(
             `skip sending content of file: ${ins.filename} due to token count: ${file_content_tokens}`

--- a/src/review.ts
+++ b/src/review.ts
@@ -435,14 +435,14 @@ ${comment_chain}
 
     const reviewPromises = []
     const skipped_files_to_review = []
-    for (const [filename, file_content, , hunks] of files_to_review) {
+    for (const [filename, file_content, , patches] of files_to_review) {
       if (
         options.max_files_to_review <= 0 ||
         reviewPromises.length < options.max_files_to_review
       ) {
         reviewPromises.push(
           openai_concurrency_limit(async () =>
-            do_review(filename, file_content, hunks)
+            do_review(filename, file_content, patches)
           )
         )
       } else {
@@ -542,7 +542,7 @@ const parse_hunk = (
   const old_hunk_lines: string[] = []
   const new_hunk_lines: string[] = []
 
-  let old_line = hunkInfo.old_hunk.start_line
+  //let old_line = hunkInfo.old_hunk.start_line
   let new_line = hunkInfo.new_hunk.start_line
 
   const lines = hunk.split('\n').slice(1) // Skip the @@ line
@@ -555,14 +555,14 @@ const parse_hunk = (
   lines.forEach(line => {
     if (line.startsWith('-')) {
       old_hunk_lines.push(`${line.substring(1)}`)
-      old_line++
+      //old_line++
     } else if (line.startsWith('+')) {
       new_hunk_lines.push(`${new_line}: ${line.substring(1)}`)
       new_line++
     } else {
       old_hunk_lines.push(`${line}`)
       new_hunk_lines.push(`${new_line}: ${line}`)
-      old_line++
+      //old_line++
       new_line++
     }
   })

--- a/src/review.ts
+++ b/src/review.ts
@@ -369,7 +369,6 @@ ${
           } else {
             comment_chain = ''
           }
-          core.info(`comment_chain: ${comment_chain}`)
           // check comment_chain tokens and skip if too long
           const comment_chain_tokens = tokenizer.get_token_count(comment_chain)
           if (

--- a/src/review.ts
+++ b/src/review.ts
@@ -387,18 +387,18 @@ ${
             )
           }
         }
-        ins.hunks += `
+        ins.patches += `
 ${patch}
 `
         if (comment_chain !== '') {
-          ins.hunks += `
+          ins.patches += `
 \`\`\`comment_chain
 ${comment_chain}
 \`\`\`
 `
         }
 
-        ins.hunks += `
+        ins.patches += `
 ---
 `
       }

--- a/src/review.ts
+++ b/src/review.ts
@@ -131,7 +131,6 @@ export const codeReview = async (
 \`\`\`
 ${hunks.old_hunk}
 \`\`\`
----
 new_hunk:
 \`\`\`
 ${hunks.new_hunk}
@@ -395,6 +394,7 @@ ${patch}
 `
         if (comment_chain !== '') {
           ins.patches += `
+comment_chain:
 \`\`\`text
 ${comment_chain}
 \`\`\`

--- a/src/review.ts
+++ b/src/review.ts
@@ -123,7 +123,7 @@ export const codeReview = async (
         if (!patch_lines) {
           continue
         }
-        const hunks = parse_hunk(patch)
+        const hunks = parse_patch(patch)
         if (!hunks) {
           continue
         }
@@ -531,10 +531,10 @@ const patch_start_end_line = (
   }
 }
 
-const parse_hunk = (
-  hunk: string
+const parse_patch = (
+  patch: string
 ): {old_hunk: string; new_hunk: string} | null => {
-  const hunkInfo = patch_start_end_line(hunk)
+  const hunkInfo = patch_start_end_line(patch)
   if (!hunkInfo) {
     return null
   }
@@ -545,7 +545,7 @@ const parse_hunk = (
   //let old_line = hunkInfo.old_hunk.start_line
   let new_line = hunkInfo.new_hunk.start_line
 
-  const lines = hunk.split('\n').slice(1) // Skip the @@ line
+  const lines = patch.split('\n').slice(1) // Skip the @@ line
 
   // Remove the last line if it's empty
   if (lines[lines.length - 1] === '') {

--- a/src/review.ts
+++ b/src/review.ts
@@ -552,7 +552,7 @@ const parse_patch = (
     lines.pop()
   }
 
-  lines.forEach(line => {
+  for (const line of lines) {
     if (line.startsWith('-')) {
       old_hunk_lines.push(`${line.substring(1)}`)
       //old_line++
@@ -565,7 +565,7 @@ const parse_patch = (
       //old_line++
       new_line++
     }
-  })
+  }
 
   return {
     old_hunk: old_hunk_lines.join('\n'),

--- a/src/review.ts
+++ b/src/review.ts
@@ -328,14 +328,6 @@ ${
       ins.filename = filename
 
       if (file_content.length > 0) {
-        const lines = file_content.split('\n')
-        let line_number = 1
-        file_content = ''
-        for (const line of lines) {
-          file_content += `${line_number}: ${line}
-`
-          line_number += 1
-        }
         const file_content_tokens = tokenizer.get_token_count(file_content)
         if (
           file_content_tokens < options.heavy_token_limits.extra_content_tokens
@@ -562,13 +554,13 @@ const parse_hunk = (
 
   lines.forEach(line => {
     if (line.startsWith('-')) {
-      old_hunk_lines.push(`${old_line}: ${line.substring(1)}`)
+      old_hunk_lines.push(`${line.substring(1)}`)
       old_line++
     } else if (line.startsWith('+')) {
       new_hunk_lines.push(`${new_line}: ${line.substring(1)}`)
       new_line++
     } else {
-      old_hunk_lines.push(`${old_line}: ${line}`)
+      old_hunk_lines.push(`${line}`)
       new_hunk_lines.push(`${new_line}: ${line}`)
       old_line++
       new_line++

--- a/src/review.ts
+++ b/src/review.ts
@@ -329,21 +329,21 @@ ${
       ins.filename = filename
 
       if (file_content.length > 0) {
+        // rewrite file_content to preprend line numbers and colon before each line
+        const lines = file_content.split('\n')
+        let line_number = 1
+        file_content = ''
+        for (const line of lines) {
+          file_content += `${line_number}: ${line}
+`
+          line_number += 1
+        }
+        core.info(`file_content: ${file_content}`)
         const file_content_tokens = tokenizer.get_token_count(file_content)
         if (
           file_content_tokens < options.heavy_token_limits.extra_content_tokens
         ) {
-          // rewrite file_content to preprend line numbers and colon before each line
-          const lines = file_content.split('\n')
-          let line_number = 1
-          file_content = ''
-          for (const line of lines) {
-            file_content += `${line_number}: ${line}
-`
-            line_number += 1
-          }
           ins.file_content = file_content
-          core.info(`file_content: ${file_content}`)
         } else {
           core.info(
             `skip sending content of file: ${ins.filename} due to token count: ${file_content_tokens}`
@@ -557,6 +557,11 @@ const parse_hunk = (
   let new_line = hunkInfo.new_hunk.start_line
 
   const lines = hunk.split('\n').slice(1) // Skip the @@ line
+
+  // Remove the last line if it's empty
+  if (lines[lines.length - 1] === '') {
+    lines.pop()
+  }
 
   lines.forEach(line => {
     if (line.startsWith('-')) {

--- a/src/review.ts
+++ b/src/review.ts
@@ -127,12 +127,12 @@ export const codeReview = async (
         if (!hunks) {
           continue
         }
-        const hunks_str = `old hunk:
+        const hunks_str = `old_hunk:
 \`\`\`
 ${hunks.old_hunk}
 \`\`\`
 ---
-new hunk:
+new_hunk:
 \`\`\`
 ${hunks.new_hunk}
 \`\`\`

--- a/src/review.ts
+++ b/src/review.ts
@@ -120,14 +120,28 @@ export const codeReview = async (
       const patches: [number, number, string][] = []
       for (const patch of split_patch(file.patch)) {
         const patch_lines = patch_start_end_line(patch)
-        if (
-          !patch_lines ||
-          patch_lines.start_line === -1 ||
-          patch_lines.end_line === -1
-        ) {
+        if (!patch_lines) {
           continue
         }
-        patches.push([patch_lines.start_line, patch_lines.end_line, patch])
+        const hunks = parse_hunk(patch)
+        if (!hunks) {
+          continue
+        }
+        const hunks_str = `old hunk:
+\`\`\`
+${hunks.old_hunk}
+\`\`\`
+---
+new hunk:
+\`\`\`
+${hunks.new_hunk}
+\`\`\`
+`
+        patches.push([
+          patch_lines.new_hunk.start_line,
+          patch_lines.new_hunk.end_line,
+          hunks_str
+        ])
       }
       if (patches.length > 0) {
         return [file.filename, file_content, file_diff, patches]
@@ -319,6 +333,15 @@ ${
         if (
           file_content_tokens < options.heavy_token_limits.extra_content_tokens
         ) {
+          // rewrite file_content to preprend line numbers and colon before each line
+          const lines = file_content.split('\n')
+          let line_number = 1
+          file_content = ''
+          for (const line of lines) {
+            file_content += `${line_number}: ${line}
+`
+            line_number += 1
+          }
           ins.file_content = file_content
         } else {
           core.info(
@@ -348,6 +371,17 @@ ${
           } else {
             comment_chain = ''
           }
+          // check comment_chain tokens and skip if too long
+          const comment_chain_tokens = tokenizer.get_token_count(comment_chain)
+          if (
+            comment_chain_tokens >
+            options.heavy_token_limits.extra_content_tokens
+          ) {
+            core.info(
+              `skip sending comment chain of file: ${ins.filename} due to token count: ${comment_chain_tokens}`
+            )
+            comment_chain = ''
+          }
         } catch (e: unknown) {
           if (e instanceof ChatGPTError) {
             core.warning(
@@ -356,10 +390,7 @@ ${
           }
         }
         ins.patches += `
-${start_line}-${end_line}:
-\`\`\`diff
 ${patch}
-\`\`\`
 `
         if (comment_chain !== '') {
           ins.patches += `
@@ -484,18 +515,66 @@ const split_patch = (patch: string | null | undefined): string[] => {
 
 const patch_start_end_line = (
   patch: string
-): {start_line: number; end_line: number} | null => {
+): {
+  old_hunk: {start_line: number; end_line: number}
+  new_hunk: {start_line: number; end_line: number}
+} | null => {
   const pattern = /(^@@ -(\d+),(\d+) \+(\d+),(\d+) @@)/gm
   const match = pattern.exec(patch)
   if (match) {
-    const begin = parseInt(match[4])
-    const diff = parseInt(match[5])
+    const old_begin = parseInt(match[2])
+    const old_diff = parseInt(match[3])
+    const new_begin = parseInt(match[4])
+    const new_diff = parseInt(match[5])
     return {
-      start_line: begin,
-      end_line: begin + diff - 1
+      old_hunk: {
+        start_line: old_begin,
+        end_line: old_begin + old_diff - 1
+      },
+      new_hunk: {
+        start_line: new_begin,
+        end_line: new_begin + new_diff - 1
+      }
     }
   } else {
     return null
+  }
+}
+
+const parse_hunk = (
+  hunk: string
+): {old_hunk: string; new_hunk: string} | null => {
+  const hunkInfo = patch_start_end_line(hunk)
+  if (!hunkInfo) {
+    return null
+  }
+
+  const old_hunk_lines: string[] = []
+  const new_hunk_lines: string[] = []
+
+  let old_line = hunkInfo.old_hunk.start_line
+  let new_line = hunkInfo.new_hunk.start_line
+
+  const lines = hunk.split('\n').slice(1) // Skip the @@ line
+
+  lines.forEach(line => {
+    if (line.startsWith('-')) {
+      old_hunk_lines.push(`${old_line}: ${line.substring(1)}`)
+      old_line++
+    } else if (line.startsWith('+')) {
+      new_hunk_lines.push(`${new_line}: ${line.substring(1)}`)
+      new_line++
+    } else {
+      old_hunk_lines.push(`${old_line}: ${line}`)
+      new_hunk_lines.push(`${new_line}: ${line}`)
+      old_line++
+      new_line++
+    }
+  })
+
+  return {
+    old_hunk: old_hunk_lines.join('\n'),
+    new_hunk: new_hunk_lines.join('\n')
   }
 }
 


### PR DESCRIPTION


















<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- New Feature: Changes the format of review comments in GitHub to include line number ranges and markdown formatting for text and code snippets. Reviewers can now provide more thorough feedback on potential issues or improvements.
- Refactor: Changes the terminology from "patches" to "hunks" in `src/review.ts` and modifies the code accordingly. It also adds a check for comment chain tokens and skips sending if too long.

> "Code reviews made better,  
> With line numbers and markdown formatting galore.  
> Patches are now hunks,  
> And comment chains won't be a bore."
<!-- end of auto-generated comment: release notes by openai -->