### PR TITLE
improve review_section demarcation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,47 @@ request.
 
 See: [action.yml](./action.yml)
 
+Tip: You can change the bot personality by configuring the `system_message`
+value. For example, to review docs/blog posts, you can use the following prompt:
+
+<details>
+<summary>Blog Reviewer Prompt</summary>
+
+```yaml
+system_message: |
+  You are `@openai` (aka `github-actions[bot]`), a language model
+  trained by OpenAI. Your purpose is to act as a highly experienced
+  DevRel (developer relations) professional with focus on cloud-native
+  infrastructure.
+
+  Company context -
+  FluxNinja is a cloud-native intelligent load management platform.
+  The platform is powered by Aperture, an open-source project, which
+  provides a control systems inspired policy language for defining
+  observability driven control loop. FluxNinja's load management,
+  such as prioritized load shedding and load-based autoscaling,
+  ensures system stability. FluxNinja ARC, the commercial solution,
+  offers advanced analytics, intelligent alerting, and policy
+  visualization.
+
+  When reviewing or generating content focus on key areas such as -
+  - Accuracy
+  - Relevance
+  - Clarity
+  - Technical depth
+  - Call-to-action
+  - SEO optimization
+  - Brand consistency
+  - Grammar and prose
+  - Typos
+  - Hyperlink suggestions
+  - Graphics or images (suggest Dall-E image prompts if needed)
+  - Empathy
+  - Engagement
+```
+
+</details>
+
 Any suggestions or pull requests for improving the prompts are highly
 appreciated.
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -6481,12 +6481,10 @@ const codeReview = async (lightBot, heavyBot, options, prompts) => {
                 continue;
             }
             const hunks_str = `
-\`\`\`new_hunk_for_review
+---new_hunk_for_review---
 ${hunks.new_hunk}
-\`\`\`
-\`\`\`old_hunk_for_context
+---old_hunk_for_context---
 ${hunks.old_hunk}
-\`\`\`
 `;
             patches.push([
                 patch_lines.new_hunk.start_line,
@@ -6665,16 +6663,13 @@ ${summaries_failed.length > 0
         // Pack instructions
         ins.patches += `
 Format for changes and review comments (if any) -
-  \`\`\`new_hunk_for_review
+  ---new_hunk_for_review---
   <new content annotated with line numbers>
-  \`\`\`
-  \`\`\`old_hunk_for_context
+  ---old_hunk_for_context---
   <old content>
-  \`\`\`
-  \`\`\`comment_chains_for_context
+  ---comment_chains_for_context---
   <comment chains>
-  \`\`\`
-  ---
+  ---end_review_section---
   ...
 
 Response format expected -
@@ -6792,13 +6787,12 @@ ${patch}
 `;
             if (comment_chain !== '') {
                 ins.patches += `
-\`\`\`comment_chains_for_review
+---comment_chains_for_review---
 ${comment_chain}
-\`\`\`
 `;
             }
             ins.patches += `
----
+---end_review_section---
 `;
         }
         // perform review

--- a/src/review.ts
+++ b/src/review.ts
@@ -131,12 +131,10 @@ export const codeReview = async (
           continue
         }
         const hunks_str = `
-\`\`\`new_hunk_for_review
+---new_hunk_for_review---
 ${hunks.new_hunk}
-\`\`\`
-\`\`\`old_hunk_for_context
+---old_hunk_for_context---
 ${hunks.old_hunk}
-\`\`\`
 `
         patches.push([
           patch_lines.new_hunk.start_line,
@@ -369,16 +367,13 @@ ${
     // Pack instructions
     ins.patches += `
 Format for changes and review comments (if any) -
-  \`\`\`new_hunk_for_review
+  ---new_hunk_for_review---
   <new content annotated with line numbers>
-  \`\`\`
-  \`\`\`old_hunk_for_context
+  ---old_hunk_for_context---
   <old content>
-  \`\`\`
-  \`\`\`comment_chains_for_context
+  ---comment_chains_for_context---
   <comment chains>
-  \`\`\`
-  ---
+  ---end_review_section---
   ...
 
 Response format expected -
@@ -514,14 +509,13 @@ ${patch}
 `
       if (comment_chain !== '') {
         ins.patches += `
-\`\`\`comment_chains_for_review
+---comment_chains_for_review---
 ${comment_chain}
-\`\`\`
 `
       }
 
       ins.patches += `
----
+---end_review_section---
 `
     }
     // perform review


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

## Release Notes

- Documentation: Added a tip to change the bot personality by configuring the `system_message` value in `README.md`. It provides an example prompt for reviewing docs/blog posts with a focus on accuracy, relevance, clarity, technical depth, call-to-action, SEO optimization, brand consistency, grammar and prose, typos, hyperlink suggestions, graphics or images, empathy, and engagement.
- Refactor: Improved the demarcation of review sections in `src/review.ts` by replacing code blocks with hyphens and adding an `end_review_section` marker. It also removes unnecessary code and comments.

> "Code reviewed with care,
> Now more readable and fair,
> Bot's personality shines."
<!-- end of auto-generated comment: release notes by openai -->