### PR TITLE
add instructions for inclusive line number ranges

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6695,6 +6695,11 @@ Format for changes:
   ---end_change_section---
   ...
 
+The above format for changes consistes of multiple change sections. 
+Each change section consists of a new hunk (annotated with line numbers), 
+an old hunk (that was replaced with new hunk) and optionally, comment 
+chains for context.
+
 Hunks for review are below:
 `;
         // calculate tokens based on inputs so far
@@ -6770,6 +6775,10 @@ ${comment_chain}
         // add instructions
         ins.patches += `
 Instructions for you:
+- Your task is to do a line by line review of new hunks and point out 
+  substantive issues in those line number ranges. When commenting, 
+  you will need to provide the exact line number range (inclusive) 
+  for each issue that is detected.
 - Only respond in the below response format (consisting of review
   sections) and nothing else. Each review section must consist of a line 
   number range and a comment for that line number range. Optionally, 
@@ -6798,7 +6807,6 @@ Instructions for you:
   fenced code blocks. These snippets may be added to a different file, such 
   as test cases.
 - Do not annotate code snippets with line numbers inside the code blocks.
-- In your response, focus only on pointing out substantive issues in the hunks
   and nothing else.
 - If there are no issues in a hunk, comment "LGTM!" for the respective line range.
 - Review your comments and line number ranges at least 3 times before sending 
@@ -6823,7 +6831,7 @@ Response format expected:
   ---
   ...
 
-Example request:
+Example changes:
   ---new_hunk_for_review---
   1: def add(x, y):
   2:     z = x+y

--- a/dist/index.js
+++ b/dist/index.js
@@ -6779,7 +6779,7 @@ Instructions for you:
   be within the line number range of a specific new hunk. i.e. 
   <start_line_number> must belong to the same hunk as the 
   <end_line_number>. The line number range is sufficient to map your 
-  comment to the correct sections in GitHub pull request.
+  comment to the code changes in GitHub pull request.
 - Consider the context provided by the old hunk and associated comment 
   chain when reviewing the new hunk.
 - Use Markdown format for review comment text.

--- a/dist/index.js
+++ b/dist/index.js
@@ -6770,11 +6770,11 @@ ${comment_chain}
         // add instructions
         ins.patches += `
 Instructions for you:
-- Only respond in the below response format and nothing else. Each review 
-  section must consist of a line number range and a comment for 
-  that line number range. Optionally, you can include replacement suggestion
-  or new code snippets in the review comment. There's a separator between 
-  review sections.
+- Only respond in the below response format consisting of multiple review
+  sections and nothing else. Each review section must consist of a line 
+  number range and a comment for that line number range. Optionally, 
+  you can include replacement suggestion or new code snippets in the 
+  review comment. There's a separator between review sections.
 - It's important that line number ranges for each review section must 
   be within the line number range of a specific new hunk. i.e. 
   <start_line_number> must belong to the same hunk as the 
@@ -6785,13 +6785,15 @@ Instructions for you:
 - Use Markdown format for review comment text.
 - Fenced code blocks must be used for new content and replacement 
   code/text snippets. 
-- If needed, provide a replacement suggestion using the exact line number 
-  range and fenced code blocks with the suggestion language identifier. 
-  These can be directly committed by the user in the GitHub UI. Replacement 
-  code/text snippets must be complete and correctly formatted. For instance, 
+- If needed, provide a replacement suggestion using fenced code blocks 
+  with the \`suggestion\` as the language identifier. The line number range 
+  in the review section must map exactly to the line number range (inclusive) 
+  that need to be replaced within a new_hunk_for_review. These snippets will be 
+  directly committed by the user using the GitHub UI. For instance, 
   if 2 lines of code in a hunk need to be replaced with 15 lines of code, 
-  the line number range must be those exact 2 lines. If an entire hunk need to
-  be replaced with new code, then the line number range must be the entire hunk.
+  the line number range must be those exact 2 lines. If an entire hunk need 
+  to be replaced with new code, then the line number range must be the entire 
+  hunk. Replacement code/text snippets must be complete and correctly formatted. 
 - If needed, suggest new code using the correct language identifier in the 
   fenced code blocks. These snippets may be added to a different file, such 
   as test cases.

--- a/dist/index.js
+++ b/dist/index.js
@@ -6770,8 +6770,8 @@ ${comment_chain}
         // add instructions
         ins.patches += `
 Instructions for you:
-- Only respond in the below response format consisting of multiple review
-  sections and nothing else. Each review section must consist of a line 
+- Only respond in the below response format (consisting of review
+  sections) and nothing else. Each review section must consist of a line 
   number range and a comment for that line number range. Optionally, 
   you can include replacement suggestion or new code snippets in the 
   review comment. There's a separator between review sections.

--- a/src/review.ts
+++ b/src/review.ts
@@ -502,8 +502,8 @@ Instructions for you:
   code/text snippets. 
 - If needed, provide a replacement suggestion using fenced code blocks 
   with the \`suggestion\` as the language identifier. The line number range 
-  in the review section must map exactly to the line number range that need 
-  to be replaced within a new_hunk_for_review. These snippets will be 
+  in the review section must map exactly to the line number range (inclusive) 
+  that need to be replaced within a new_hunk_for_review. These snippets will be 
   directly committed by the user using the GitHub UI. For instance, 
   if 2 lines of code in a hunk need to be replaced with 15 lines of code, 
   the line number range must be those exact 2 lines. If an entire hunk need 

--- a/src/review.ts
+++ b/src/review.ts
@@ -485,8 +485,8 @@ ${comment_chain}
     // add instructions
     ins.patches += `
 Instructions for you:
-- Only respond in the below response format consisting of multiple review
-  sections and nothing else. Each review section must consist of a line 
+- Only respond in the below response format (consisting of review
+  sections) and nothing else. Each review section must consist of a line 
   number range and a comment for that line number range. Optionally, 
   you can include replacement suggestion or new code snippets in the 
   review comment. There's a separator between review sections.

--- a/src/review.ts
+++ b/src/review.ts
@@ -390,6 +390,11 @@ Format for changes:
   ---end_change_section---
   ...
 
+The above format for changes consistes of multiple change sections. 
+Each change section consists of a new hunk (annotated with line numbers), 
+an old hunk (that was replaced with new hunk) and optionally, comment 
+chains for context.
+
 Hunks for review are below:
 `
 
@@ -485,6 +490,10 @@ ${comment_chain}
     // add instructions
     ins.patches += `
 Instructions for you:
+- Your task is to do a line by line review of new hunks and point out 
+  substantive issues in those line number ranges. When commenting, 
+  you will need to provide the exact line number range (inclusive) 
+  for each issue that is detected.
 - Only respond in the below response format (consisting of review
   sections) and nothing else. Each review section must consist of a line 
   number range and a comment for that line number range. Optionally, 
@@ -513,7 +522,6 @@ Instructions for you:
   fenced code blocks. These snippets may be added to a different file, such 
   as test cases.
 - Do not annotate code snippets with line numbers inside the code blocks.
-- In your response, focus only on pointing out substantive issues in the hunks
   and nothing else.
 - If there are no issues in a hunk, comment "LGTM!" for the respective line range.
 - Review your comments and line number ranges at least 3 times before sending 
@@ -538,7 +546,7 @@ Response format expected:
   ---
   ...
 
-Example request:
+Example changes:
   ---new_hunk_for_review---
   1: def add(x, y):
   2:     z = x+y

--- a/src/review.ts
+++ b/src/review.ts
@@ -494,7 +494,7 @@ Instructions for you:
   be within the line number range of a specific new hunk. i.e. 
   <start_line_number> must belong to the same hunk as the 
   <end_line_number>. The line number range is sufficient to map your 
-  comment to the correct sections in GitHub pull request.
+  comment to the code changes in GitHub pull request.
 - Consider the context provided by the old hunk and associated comment 
   chain when reviewing the new hunk.
 - Use Markdown format for review comment text.


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Release Notes**

- Documentation: Adds instructions for doing a line by line review of new code hunks and pointing out substantive issues in those line number ranges. The instructions include guidelines on how to comment, provide replacement suggestions, and use Markdown format for review comments.

> "Code review made easy,
> With instructions clear and breezy.
> Find bugs and fix them fast,
> And make your code forever last."
<!-- end of auto-generated comment: release notes by openai -->