### PR TITLE
refactor: single suggestion per review section

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6798,13 +6798,14 @@ Instructions for you:
 - If needed, provide a replacement suggestion using fenced code blocks 
   with the \`suggestion\` as the language identifier. The line number range 
   in the review section must map exactly to the line number range (inclusive) 
-  that need to be replaced within a new_hunk_for_review. Each replacement 
-  suggestion must be provided as a separate review section with relevant 
-  line number ranges. For instance, if 2 lines of code in a hunk need to be 
-  replaced with 15 lines of code, the line number range must be those exact 
-  2 lines. If an entire hunk need to be replaced with new code, then the 
-  line number range must be the entire hunk. Replacement code/text snippets 
-  must be complete and correctly formatted. 
+  that need to be replaced within a new_hunk_for_review.
+  For instance, if 2 lines of code in a hunk need to be replaced with 15 lines 
+  of code, the line number range must be those exact 2 lines. If an entire hunk 
+  need to be replaced with new code, then the line number range must be the 
+  entire hunk. 
+- Replacement code/text snippets must be complete and correctly 
+  formatted. Each replacement suggestion must be provided as a separate review 
+  section with relevant line number ranges.  
 - If needed, suggest new code using the correct language identifier in the 
   fenced code blocks. These snippets may be added to a different file, such 
   as test cases.

--- a/dist/index.js
+++ b/dist/index.js
@@ -6782,8 +6782,9 @@ Instructions for you:
 - Only respond in the below response format (consisting of review
   sections) and nothing else. Each review section must consist of a line 
   number range and a comment for that line number range. Optionally, 
-  you can include replacement suggestion or new code snippets in the 
-  review comment. There's a separator between review sections.
+  you can include a single replacement suggestion snippet or new code 
+  snippets in the review comment. There's a separator between review 
+  sections.
 - It's important that line number ranges for each review section must 
   be within the line number range of a specific new hunk. i.e. 
   <start_line_number> must belong to the same hunk as the 
@@ -6797,12 +6798,13 @@ Instructions for you:
 - If needed, provide a replacement suggestion using fenced code blocks 
   with the \`suggestion\` as the language identifier. The line number range 
   in the review section must map exactly to the line number range (inclusive) 
-  that need to be replaced within a new_hunk_for_review. These snippets will be 
-  directly committed by the user using the GitHub UI. For instance, 
-  if 2 lines of code in a hunk need to be replaced with 15 lines of code, 
-  the line number range must be those exact 2 lines. If an entire hunk need 
-  to be replaced with new code, then the line number range must be the entire 
-  hunk. Replacement code/text snippets must be complete and correctly formatted. 
+  that need to be replaced within a new_hunk_for_review. Each replacement 
+  suggestion must be provided as a separate review section with relevant 
+  line number ranges. For instance, if 2 lines of code in a hunk need to be 
+  replaced with 15 lines of code, the line number range must be those exact 
+  2 lines. If an entire hunk need to be replaced with new code, then the 
+  line number range must be the entire hunk. Replacement code/text snippets 
+  must be complete and correctly formatted. 
 - If needed, suggest new code using the correct language identifier in the 
   fenced code blocks. These snippets may be added to a different file, such 
   as test cases.

--- a/src/review.ts
+++ b/src/review.ts
@@ -497,8 +497,9 @@ Instructions for you:
 - Only respond in the below response format (consisting of review
   sections) and nothing else. Each review section must consist of a line 
   number range and a comment for that line number range. Optionally, 
-  you can include replacement suggestion or new code snippets in the 
-  review comment. There's a separator between review sections.
+  you can include a single replacement suggestion snippet or new code 
+  snippets in the review comment. There's a separator between review 
+  sections.
 - It's important that line number ranges for each review section must 
   be within the line number range of a specific new hunk. i.e. 
   <start_line_number> must belong to the same hunk as the 
@@ -512,12 +513,13 @@ Instructions for you:
 - If needed, provide a replacement suggestion using fenced code blocks 
   with the \`suggestion\` as the language identifier. The line number range 
   in the review section must map exactly to the line number range (inclusive) 
-  that need to be replaced within a new_hunk_for_review. These snippets will be 
-  directly committed by the user using the GitHub UI. For instance, 
-  if 2 lines of code in a hunk need to be replaced with 15 lines of code, 
-  the line number range must be those exact 2 lines. If an entire hunk need 
-  to be replaced with new code, then the line number range must be the entire 
-  hunk. Replacement code/text snippets must be complete and correctly formatted. 
+  that need to be replaced within a new_hunk_for_review. Each replacement 
+  suggestion must be provided as a separate review section with relevant 
+  line number ranges. For instance, if 2 lines of code in a hunk need to be 
+  replaced with 15 lines of code, the line number range must be those exact 
+  2 lines. If an entire hunk need to be replaced with new code, then the 
+  line number range must be the entire hunk. Replacement code/text snippets 
+  must be complete and correctly formatted. 
 - If needed, suggest new code using the correct language identifier in the 
   fenced code blocks. These snippets may be added to a different file, such 
   as test cases.

--- a/src/review.ts
+++ b/src/review.ts
@@ -513,13 +513,14 @@ Instructions for you:
 - If needed, provide a replacement suggestion using fenced code blocks 
   with the \`suggestion\` as the language identifier. The line number range 
   in the review section must map exactly to the line number range (inclusive) 
-  that need to be replaced within a new_hunk_for_review. Each replacement 
-  suggestion must be provided as a separate review section with relevant 
-  line number ranges. For instance, if 2 lines of code in a hunk need to be 
-  replaced with 15 lines of code, the line number range must be those exact 
-  2 lines. If an entire hunk need to be replaced with new code, then the 
-  line number range must be the entire hunk. Replacement code/text snippets 
-  must be complete and correctly formatted. 
+  that need to be replaced within a new_hunk_for_review.
+  For instance, if 2 lines of code in a hunk need to be replaced with 15 lines 
+  of code, the line number range must be those exact 2 lines. If an entire hunk 
+  need to be replaced with new code, then the line number range must be the 
+  entire hunk. 
+- Replacement code/text snippets must be complete and correctly 
+  formatted. Each replacement suggestion must be provided as a separate review 
+  section with relevant line number ranges.  
 - If needed, suggest new code using the correct language identifier in the 
   fenced code blocks. These snippets may be added to a different file, such 
   as test cases.


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

### Release Notes

- Refactor: The review process has been updated to allow only one replacement suggestion or new code snippet per review section, and the instructions for providing replacement suggestions have been clarified.

> "Code reviews made better,
> One suggestion at a time.
> Clarity and consistency,
> Our code now sublime."
<!-- end of auto-generated comment: release notes by openai -->