### PR TITLE
create review instead of single comments

### DIFF
--- a/src/commenter.ts
+++ b/src/commenter.ts
@@ -129,9 +129,14 @@ ${tag}`
     }
   }
 
-  async review_comment(
-    pull_number: number,
-    commit_id: string,
+  private reviewCommentsBuffer: {
+    path: string
+    start_line: number
+    end_line: number
+    message: string
+  }[] = []
+
+  async buffer_review_comment(
     path: string,
     start_line: number,
     end_line: number,
@@ -143,66 +148,36 @@ ${tag}`
 ${message}
 
 ${tag}`
-    // replace comment made by this action
-    try {
-      let found = false
-      const comments = await this.get_comments_at_range(
-        pull_number,
-        path,
-        start_line,
-        end_line
-      )
-      for (const comment of comments) {
-        if (comment.body.includes(tag)) {
-          core.info(
-            `Updating review comment for ${path}:${start_line}-${end_line}: ${message}`
-          )
-          await octokit.pulls.updateReviewComment({
-            owner: repo.owner,
-            repo: repo.repo,
-            comment_id: comment.id,
-            body: message
-          })
-          found = true
-          break
-        }
-      }
 
-      if (!found) {
-        core.info(
-          `Creating new review comment for ${path}:${start_line}-${end_line}: ${message}`
-        )
-        // if start_line is same as end_line, it's a single line comment
-        // otherwise it's a multi-line comment
-        if (start_line === end_line) {
-          await octokit.pulls.createReviewComment({
-            owner: repo.owner,
-            repo: repo.repo,
-            pull_number,
-            body: message,
-            commit_id,
-            path,
-            line: end_line
-          })
-        } else {
-          await octokit.pulls.createReviewComment({
-            owner: repo.owner,
-            repo: repo.repo,
-            pull_number,
-            body: message,
-            commit_id,
-            path,
-            line: end_line,
-            start_line,
+    this.reviewCommentsBuffer.push({
+      path,
+      start_line,
+      end_line,
+      message
+    })
+  }
+
+  async submit_review(pull_number: number, commit_id: string) {
+    try {
+      if (this.reviewCommentsBuffer.length > 0) {
+        await octokit.pulls.createReview({
+          owner: repo.owner,
+          repo: repo.repo,
+          pull_number,
+          commit_id,
+          event: 'COMMENT',
+          comments: this.reviewCommentsBuffer.map(comment => ({
+            path: comment.path,
+            body: comment.message,
+            line: comment.end_line,
+            start_line: comment.start_line,
             start_side: 'RIGHT'
-          })
-        }
+          }))
+        })
+        this.reviewCommentsBuffer = []
       }
     } catch (e) {
-      core.warning(
-        `Failed to post review comment, for ${path}:${start_line}-${end_line}: ${e}`
-      )
-      // throw error
+      core.warning(`Failed to submit review: ${e}`)
       throw e
     }
   }

--- a/src/review.ts
+++ b/src/review.ts
@@ -610,9 +610,7 @@ ${comment_chain}
             continue
           }
           try {
-            await commenter.review_comment(
-              context.payload.pull_request.number,
-              commits[commits.length - 1].sha,
+            await commenter.buffer_review_comment(
               filename,
               review.start_line,
               review.end_line,
@@ -752,6 +750,12 @@ ${
 
   // post the final summary comment
   await commenter.comment(`${summarize_comment}`, SUMMARIZE_TAG, 'replace')
+
+  // post the review
+  await commenter.submit_review(
+    context.payload.pull_request.number,
+    commits[commits.length - 1].sha
+  )
 }
 
 const split_patch = (patch: string | null | undefined): string[] => {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

### Release Notes
- New Feature: Introduces a buffer for review comments and a new method to submit the buffered comments as a single review.
- Refactor: Replaces single comments with a review, and adds a new function to buffer review comments before submitting the final review.

> "Code reviews made easy,<br>
> With buffers that are breezy.<br>
> Single comments no more,<br>
> Reviews now galore.<br>
> A refactor here and there,<br>
> Makes the code easier to bear."
<!-- end of auto-generated comment: release notes by openai -->