### PR TITLE
sanitize review start_line/end_line

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6821,6 +6821,31 @@ ${comment_chain}
                         core.warning('No pull request found, skipping.');
                         continue;
                     }
+                    // sanitize review's start_line and end_line
+                    // with patches' start_line and end_line
+                    // if needed adjust start_line and end_line
+                    // to make it fit within a closest patch
+                    let within_patch = false;
+                    let closest_start_line = patches[0][0];
+                    let closest_end_line = patches[0][1];
+                    for (const [start_line, end_line] of patches) {
+                        // see if review is within some patch
+                        if (review.start_line >= start_line) {
+                            closest_start_line = start_line;
+                            closest_end_line = end_line;
+                            if (review.end_line <= end_line) {
+                                within_patch = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (!within_patch || review.start_line > review.end_line) {
+                        // map the review to the closest patch
+                        review.comment = `> Note: This review was outside of the patch, so it was mapped it to the closest patch. Original lines [${review.start_line}-${review.end_line}]
+${review.comment}`;
+                        review.start_line = closest_start_line;
+                        review.end_line = closest_end_line;
+                    }
                     try {
                         await commenter.buffer_review_comment(filename, review.start_line, review.end_line, `${review.comment}`);
                     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -3646,13 +3646,18 @@ ${tag}`;
                     pull_number,
                     commit_id,
                     event: 'COMMENT',
-                    comments: this.reviewCommentsBuffer.map(comment => ({
-                        path: comment.path,
-                        body: comment.message,
-                        line: comment.end_line,
-                        start_line: comment.start_line,
-                        start_side: 'RIGHT'
-                    }))
+                    comments: this.reviewCommentsBuffer.map(comment => {
+                        const commentData = {
+                            path: comment.path,
+                            body: comment.message,
+                            line: comment.end_line,
+                            start_side: 'RIGHT'
+                        };
+                        if (comment.start_line !== comment.end_line) {
+                            commentData.start_line = comment.start_line;
+                        }
+                        return commentData;
+                    })
                 });
                 this.reviewCommentsBuffer = [];
             }
@@ -6833,13 +6838,14 @@ ${comment_chain}
                         if (review.start_line >= start_line) {
                             closest_start_line = start_line;
                             closest_end_line = end_line;
-                            if (review.end_line <= end_line) {
+                            if (review.end_line <= end_line &&
+                                review.end_line >= start_line) {
                                 within_patch = true;
                                 break;
                             }
                         }
                     }
-                    if (!within_patch || review.start_line > review.end_line) {
+                    if (!within_patch) {
                         // map the review to the closest patch
                         review.comment = `> Note: This review was outside of the patch, so it was mapped it to the closest patch. Original lines [${review.start_line}-${review.end_line}]
 ${review.comment}`;

--- a/dist/index.js
+++ b/dist/index.js
@@ -6848,6 +6848,7 @@ ${comment_chain}
                     if (!within_patch) {
                         // map the review to the closest patch
                         review.comment = `> Note: This review was outside of the patch, so it was mapped it to the closest patch. Original lines [${review.start_line}-${review.end_line}]
+
 ${review.comment}`;
                         review.start_line = closest_start_line;
                         review.end_line = closest_end_line;

--- a/src/commenter.ts
+++ b/src/commenter.ts
@@ -148,7 +148,6 @@ ${tag}`
 ${message}
 
 ${tag}`
-
     this.reviewCommentsBuffer.push({
       path,
       start_line,
@@ -166,13 +165,20 @@ ${tag}`
           pull_number,
           commit_id,
           event: 'COMMENT',
-          comments: this.reviewCommentsBuffer.map(comment => ({
-            path: comment.path,
-            body: comment.message,
-            line: comment.end_line,
-            start_line: comment.start_line,
-            start_side: 'RIGHT'
-          }))
+          comments: this.reviewCommentsBuffer.map(comment => {
+            const commentData: any = {
+              path: comment.path,
+              body: comment.message,
+              line: comment.end_line,
+              start_side: 'RIGHT'
+            }
+
+            if (comment.start_line !== comment.end_line) {
+              commentData.start_line = comment.start_line
+            }
+
+            return commentData
+          })
         })
         this.reviewCommentsBuffer = []
       }

--- a/src/review.ts
+++ b/src/review.ts
@@ -609,6 +609,7 @@ ${comment_chain}
             core.warning('No pull request found, skipping.')
             continue
           }
+
           // sanitize review's start_line and end_line
           // with patches' start_line and end_line
           // if needed adjust start_line and end_line
@@ -627,7 +628,7 @@ ${comment_chain}
               }
             }
           }
-          if (!within_patch) {
+          if (!within_patch || review.start_line > review.end_line) {
             // map the review to the closest patch
             review.comment = `> Note: This review was outside of the patch, so it was mapped it to the closest patch. Original lines [${review.start_line}-${review.end_line}]
 ${review.comment}`

--- a/src/review.ts
+++ b/src/review.ts
@@ -635,6 +635,7 @@ ${comment_chain}
           if (!within_patch) {
             // map the review to the closest patch
             review.comment = `> Note: This review was outside of the patch, so it was mapped it to the closest patch. Original lines [${review.start_line}-${review.end_line}]
+
 ${review.comment}`
             review.start_line = closest_start_line
             review.end_line = closest_end_line

--- a/src/review.ts
+++ b/src/review.ts
@@ -622,13 +622,17 @@ ${comment_chain}
             if (review.start_line >= start_line) {
               closest_start_line = start_line
               closest_end_line = end_line
-              if (review.end_line <= end_line) {
+              if (
+                review.end_line <= end_line &&
+                review.end_line >= start_line
+              ) {
                 within_patch = true
                 break
               }
             }
           }
-          if (!within_patch || review.start_line > review.end_line) {
+
+          if (!within_patch) {
             // map the review to the closest patch
             review.comment = `> Note: This review was outside of the patch, so it was mapped it to the closest patch. Original lines [${review.start_line}-${review.end_line}]
 ${review.comment}`


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Release Notes**

- Bug fix: Added checks to ensure start and end lines are not the same before adding them to comment data. Sanitized review's start and end lines with patches' start and end lines, adjusted them if needed, and mapped reviews outside of the patch to the closest patch.

> "Code quality improved,
> Bugs squashed and logic refined,
> Our codebase shines bright."
<!-- end of auto-generated comment: release notes by openai -->