### PR TITLE
review entire PR when triggered manually

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6880,7 +6880,8 @@ ${review.comment}`;
             highest_reviewed_commit_id = getHighestReviewedCommitId(allCommitIds, getReviewedCommitIds(existing_commit_ids_block));
         }
         let files_and_changes_for_review = files_and_changes;
-        if (highest_reviewed_commit_id === '') {
+        if (highest_reviewed_commit_id === '' ||
+            highest_reviewed_commit_id === context.payload.pull_request.head.sha) {
             core.info(`Will review from the base commit: ${context.payload.pull_request.base.sha}`);
             highest_reviewed_commit_id = context.payload.pull_request.base.sha;
         }

--- a/src/review.ts
+++ b/src/review.ts
@@ -682,7 +682,10 @@ ${review.comment}`
     }
 
     let files_and_changes_for_review = files_and_changes
-    if (highest_reviewed_commit_id === '') {
+    if (
+      highest_reviewed_commit_id === '' ||
+      highest_reviewed_commit_id === context.payload.pull_request.head.sha
+    ) {
       core.info(
         `Will review from the base commit: ${context.payload.pull_request.base.sha}`
       )


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

### Release Notes

- Bug fix: Updated the condition to review all files when triggered manually or when the highest reviewed commit ID is the same as the head SHA of the pull request.

> "Code logic improved,  
> Consistency maintained.  
> Bugs fixed,  
> Quality sustained."
<!-- end of auto-generated comment: release notes by openai -->