### PR TITLE
remove sanitization code for now

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7060,37 +7060,12 @@ function parseReview(response, patches, debug = false) {
     let currentStartLine = null;
     let currentEndLine = null;
     let currentComment = '';
-    function removeLineNumbersFromSuggestion(comment) {
-        const suggestionStart = '```suggestion';
-        const suggestionEnd = '```';
-        let suggestionStartIndex = comment.indexOf(suggestionStart);
-        while (suggestionStartIndex !== -1) {
-            const suggestionEndIndex = comment.indexOf(suggestionEnd, suggestionStartIndex);
-            if (suggestionEndIndex === -1) {
-                // Break the loop if the closing delimiter is not found
-                break;
-            }
-            const suggestionBlock = comment.substring(suggestionStartIndex + suggestionStart.length, suggestionEndIndex);
-            const lineNumberRegex = /^\s*\d+:\s+/;
-            const sanitizedBlock = suggestionBlock
-                .split('\n')
-                .map(line => line.replace(lineNumberRegex, ''))
-                .join('\n');
-            comment =
-                comment.substring(0, suggestionStartIndex + suggestionStart.length) +
-                    sanitizedBlock +
-                    comment.substring(suggestionEndIndex);
-            suggestionStartIndex = comment.indexOf(suggestionStart, suggestionEndIndex + suggestionEnd.length);
-        }
-        return comment;
-    }
     function storeReview() {
         if (currentStartLine !== null && currentEndLine !== null) {
-            const sanitizedComment = removeLineNumbersFromSuggestion(currentComment.trim());
             const review = {
                 start_line: currentStartLine,
                 end_line: currentEndLine,
-                comment: sanitizedComment.trim()
+                comment: currentComment.trim()
             };
             let within_patch = false;
             let best_patch_start_line = patches[0][0];

--- a/src/review.ts
+++ b/src/review.ts
@@ -867,57 +867,12 @@ function parseReview(
   let currentStartLine: number | null = null
   let currentEndLine: number | null = null
   let currentComment = ''
-
-  function removeLineNumbersFromSuggestion(comment: string): string {
-    const suggestionStart = '```suggestion'
-    const suggestionEnd = '```'
-    let suggestionStartIndex = comment.indexOf(suggestionStart)
-
-    while (suggestionStartIndex !== -1) {
-      const suggestionEndIndex = comment.indexOf(
-        suggestionEnd,
-        suggestionStartIndex
-      )
-
-      if (suggestionEndIndex === -1) {
-        // Break the loop if the closing delimiter is not found
-        break
-      }
-
-      const suggestionBlock = comment.substring(
-        suggestionStartIndex + suggestionStart.length,
-        suggestionEndIndex
-      )
-      const lineNumberRegex = /^\s*\d+:\s+/
-
-      const sanitizedBlock = suggestionBlock
-        .split('\n')
-        .map(line => line.replace(lineNumberRegex, ''))
-        .join('\n')
-
-      comment =
-        comment.substring(0, suggestionStartIndex + suggestionStart.length) +
-        sanitizedBlock +
-        comment.substring(suggestionEndIndex)
-
-      suggestionStartIndex = comment.indexOf(
-        suggestionStart,
-        suggestionEndIndex + suggestionEnd.length
-      )
-    }
-
-    return comment
-  }
-
   function storeReview(): void {
     if (currentStartLine !== null && currentEndLine !== null) {
-      const sanitizedComment = removeLineNumbersFromSuggestion(
-        currentComment.trim()
-      )
       const review: Review = {
         start_line: currentStartLine,
         end_line: currentEndLine,
-        comment: sanitizedComment.trim()
+        comment: currentComment.trim()
       }
 
       let within_patch = false


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

### Release Notes

Bug fix: The code removes a function that sanitizes line numbers from suggestion comments in the `parseReview` function. The `storeReview` function no longer calls this removed function and instead stores the comment as is.

> "Code changes made with care,  
> Bugs fixed, we're now aware.  
> With each pull request we grow,  
> Our codebase stronger than before."
<!-- end of auto-generated comment: release notes by openai -->