### PR TITLE
update default prompts to use release_notes instead of full summary

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -177,17 +177,16 @@ inputs:
       $description
       ```
 
-      OpenAI generated summary of overall changes:
+      OpenAI generated notes:
       ```
-      $summary
+      $release_notes
       ```
 
-      Content of `$filename` prior to changes for context:
+      Content of `$filename` prior to changes:
       ```
       $file_content
       ```
 
-      Changes for review:
       $patches
   comment:
     required: false
@@ -205,9 +204,9 @@ inputs:
       $description
       ```
 
-      OpenAI generated summary:
+      OpenAI generated notes:
       ```
-      $summary
+      $release_notes
       ```
 
       Content of file prior to changes:

--- a/src/commenter.ts
+++ b/src/commenter.ts
@@ -74,6 +74,21 @@ ${tag}`
     return description
   }
 
+  get_release_notes(description: string) {
+    // get our summary from description by looking for description_tag and description_tag_end
+    // and remove any content within that which is in markdown quote (>)
+    const start = description.indexOf(DESCRIPTION_TAG)
+    const end = description.indexOf(DESCRIPTION_TAG_END)
+    if (start >= 0 && end >= 0) {
+      const release_notes = description.slice(
+        start + DESCRIPTION_TAG.length,
+        end
+      )
+      return release_notes.replace(/(^|\n)> .*/g, '')
+    }
+    return ''
+  }
+
   async update_description(pull_number: number, message: string) {
     // add this response to the description field of the PR as release notes by looking
     // for the tag (marker)

--- a/src/options.ts
+++ b/src/options.ts
@@ -48,6 +48,7 @@ export class Inputs {
   title: string
   description: string
   summary: string
+  release_notes: string
   filename: string
   file_content: string
   file_diff: string
@@ -61,6 +62,7 @@ export class Inputs {
     title = 'no title provided',
     description = 'no description provided',
     summary = 'no summary so far',
+    release_notes = 'no release notes so far',
     filename = 'unknown',
     file_content = 'file contents cannot be provided',
     file_diff = 'file diff cannot be provided',
@@ -73,6 +75,7 @@ export class Inputs {
     this.title = title
     this.description = description
     this.summary = summary
+    this.release_notes = release_notes
     this.filename = filename
     this.file_content = file_content
     this.file_diff = file_diff
@@ -88,6 +91,7 @@ export class Inputs {
       this.title,
       this.description,
       this.summary,
+      this.release_notes,
       this.filename,
       this.file_content,
       this.file_diff,
@@ -113,6 +117,9 @@ export class Inputs {
     }
     if (this.summary) {
       content = content.replace('$summary', this.summary)
+    }
+    if (this.release_notes) {
+      content = content.replace('$release_notes', this.release_notes)
     }
     if (this.filename) {
       content = content.replace('$filename', this.filename)

--- a/src/review-comment.ts
+++ b/src/review-comment.ts
@@ -47,7 +47,12 @@ export const handleReviewComment = async (
   }
   inputs.title = context.payload.pull_request.title
   if (context.payload.pull_request.body) {
-    inputs.description = context.payload.pull_request.body
+    inputs.description = commenter.get_description(
+      context.payload.pull_request.body
+    )
+    inputs.release_notes = commenter.get_release_notes(
+      context.payload.pull_request.body
+    )
   }
 
   // check if the comment was created and not edited or deleted

--- a/src/review.ts
+++ b/src/review.ts
@@ -285,6 +285,7 @@ ${filename}: ${summary}
       core.info('release notes: nothing obtained from openai')
     } else {
       next_summarize_ids = release_notes_ids
+      inputs.release_notes = release_notes_response.replace(/(^|\n)> .*/g, '')
       let message = '### Summary by OpenAI\n\n'
       message += release_notes_response
       commenter.update_description(context.payload.pull_request.number, message)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Release Notes**

New Feature: The GitHub Action now extracts release notes from pull request descriptions instead of using the full summary. This improves the user experience by providing more relevant prompts for reviewers and ensures consistency across different pull requests.

Bug Fix: The `review.ts` file is updated to remove ">" characters from release notes.

Refactor: Several files are modified to use release notes as default prompts and include error handling and token count checks.

> "Release notes extracted with ease,  
> Reviewers' prompts now aim to please.  
> Consistency and relevance abound,  
> With fewer bugs to be found."
<!-- end of auto-generated comment: release notes by openai -->