### PR TITLE
skip review of lower complexity changes

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6763,17 +6763,13 @@ ${summaries_failed.length > 0
         : ''}
 `;
     if (options.summary_only !== true) {
-        let files_and_changes_review = files_and_changes;
-        const reviews_skipped = [];
-        // filter out files that are less complex and remove them from the review
-        // loop through summaries and check the complexity flag
-        for (const [filename, , is_complex] of summaries) {
-            if (!is_complex) {
-                // remove the file from the review
-                files_and_changes_review = files_and_changes_review.filter(([file]) => file !== filename);
-                reviews_skipped.push(filename);
-            }
-        }
+        const files_and_changes_review = files_and_changes.filter(([filename]) => {
+            const is_complex = summaries.find(([summaryFilename]) => summaryFilename === filename)?.[2] ?? true;
+            return is_complex;
+        });
+        const reviews_skipped = files_and_changes
+            .filter(([filename]) => !files_and_changes_review.some(([reviewFilename]) => reviewFilename === filename))
+            .map(([filename]) => filename);
         // failed reviews array
         const reviews_failed = [];
         const do_review = async (filename, file_content, patches) => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -5865,10 +5865,10 @@ class Prompts {
 
 Below the summary, I would also like you to classify the 
 complexity of the diff as \`COMPLEX\` or \`SIMPLE\` based 
-on whether the change is a simple chore such are renaming
-a variable or a complex change such as adding a new feature.
-Any change that does not change the logic of the code is
-considered a simple change.
+on whether the change is a simple chore or a complex change 
+that needs further review. If the diff does not substantively 
+change the logic/functionality of the code, then it is a 
+simple change.
 
 Use the following format to classify the complexity of the
 diff and add no additional text:

--- a/dist/index.js
+++ b/dist/index.js
@@ -6620,12 +6620,20 @@ ${hunks.old_hunk}
                 // parse the comment to look for complexity classification
                 // Format is : [COMPLEXITY]: <COMPLEX or SIMPLE>
                 // if the change is complex return true, else false
-                const complexity = summarize_resp
-                    .split('[COMPLEXITY]: ')[1]
-                    .split('\n')[0];
-                const is_complex = complexity === 'COMPLEX' ? true : false;
-                core.info(`filename: ${filename}, complexity: ${complexity}`);
-                return [filename, summarize_resp, is_complex];
+                const complexityRegex = /\[COMPLEXITY\]:\s*(COMPLEX|SIMPLE)/;
+                const complexityMatch = summarize_resp.match(complexityRegex);
+                if (complexityMatch) {
+                    const complexity = complexityMatch[1];
+                    const is_complex = complexity === 'COMPLEX' ? true : false;
+                    // remove this line from the comment
+                    const summary = summarize_resp.replace(complexityRegex, '').trim();
+                    core.info(`filename: ${filename}, complexity: ${complexity}`);
+                    return [filename, summary, is_complex];
+                }
+                else {
+                    // Handle the case when the [COMPLEXITY] tag is not found
+                    return [filename, summarize_resp, true];
+                }
             }
         }
         catch (error) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -5865,10 +5865,8 @@ class Prompts {
 
 Below the summary, I would also like you to classify the 
 complexity of the diff as \`COMPLEX\` or \`SIMPLE\` based 
-on whether the change is a simple chore or a complex change 
-that needs further review. If the diff does not substantively 
-change the logic/functionality of the code, then it is a 
-simple change.
+on whether the diff is a simple change that looks good as it
+is or a complex change that needs thorough review.
 
 Use the following format to classify the complexity of the
 diff and add no additional text:

--- a/src/options.ts
+++ b/src/options.ts
@@ -27,7 +27,21 @@ export class Prompts {
   }
 
   render_summarize_file_diff(inputs: Inputs): string {
-    return inputs.render(this.summarize_file_diff)
+    const prompt = `${this.summarize_file_diff}
+
+Below the summary, I would also like you to classify the 
+complexity of the diff as \`COMPLEX\` or \`SIMPLE\` based 
+on whether the change is a simple chore such are renaming
+a variable or a complex change such as adding a new feature.
+Any change that does not change the logic of the code is
+considered a simple change.
+
+Use the following format to classify the complexity of the
+diff and add no additional text:
+[COMPLEXITY]: <COMPLEX or SIMPLE>
+`
+
+    return inputs.render(prompt)
   }
 
   render_summarize(inputs: Inputs): string {

--- a/src/options.ts
+++ b/src/options.ts
@@ -31,10 +31,8 @@ export class Prompts {
 
 Below the summary, I would also like you to classify the 
 complexity of the diff as \`COMPLEX\` or \`SIMPLE\` based 
-on whether the change is a simple chore or a complex change 
-that needs further review. If the diff does not substantively 
-change the logic/functionality of the code, then it is a 
-simple change.
+on whether the diff is a simple change that looks good as it
+is or a complex change that needs thorough review.
 
 Use the following format to classify the complexity of the
 diff and add no additional text:

--- a/src/options.ts
+++ b/src/options.ts
@@ -31,10 +31,10 @@ export class Prompts {
 
 Below the summary, I would also like you to classify the 
 complexity of the diff as \`COMPLEX\` or \`SIMPLE\` based 
-on whether the change is a simple chore such are renaming
-a variable or a complex change such as adding a new feature.
-Any change that does not change the logic of the code is
-considered a simple change.
+on whether the change is a simple chore or a complex change 
+that needs further review. If the diff does not substantively 
+change the logic/functionality of the code, then it is a 
+simple change.
 
 Use the following format to classify the complexity of the
 diff and add no additional text:

--- a/src/review.ts
+++ b/src/review.ts
@@ -217,7 +217,7 @@ ${hunks.old_hunk}
     filename: string,
     file_content: string,
     file_diff: string
-  ): Promise<[string, string] | null> => {
+  ): Promise<[string, string, boolean] | null> => {
     const ins = inputs.clone()
     if (file_diff.length === 0) {
       core.warning(`summarize: file_diff is empty, skip ${filename}`)
@@ -226,6 +226,7 @@ ${hunks.old_hunk}
     }
 
     ins.filename = filename
+
     // render prompt based on inputs so far
     let tokens = tokenizer.get_token_count(
       prompts.render_summarize_file_diff(ins)
@@ -268,7 +269,15 @@ ${hunks.old_hunk}
         summaries_failed.push(`${filename} (nothing obtained from openai)`)
         return null
       } else {
-        return [filename, summarize_resp]
+        // parse the comment to look for complexity classification
+        // Format is : [COMPLEXITY]: <COMPLEX or SIMPLE>
+        // if the change is complex return true, else false
+        const complexity = summarize_resp
+          .split('[COMPLEXITY]: ')[1]
+          .split('\n')[0]
+        const is_complex = complexity === 'COMPLEX' ? true : false
+        core.info(`filename: ${filename}, complexity: ${complexity}`)
+        return [filename, summarize_resp, is_complex]
       }
     } catch (error) {
       core.warning(`summarize: error from openai: ${error}`)
@@ -293,7 +302,7 @@ ${hunks.old_hunk}
 
   const summaries = (await Promise.all(summaryPromises)).filter(
     summary => summary !== null
-  ) as [string, string][]
+  ) as [string, string, boolean][]
 
   if (summaries.length > 0) {
     // join summaries into one in the batches of 20
@@ -420,6 +429,20 @@ ${
 `
 
   if (options.summary_only !== true) {
+    let files_and_changes_review = files_and_changes
+    const reviews_skipped: string[] = []
+    // filter out files that are less complex and remove them from the review
+    // loop through summaries and check the complexity flag
+    for (const [filename, , is_complex] of summaries) {
+      if (!is_complex) {
+        // remove the file from the review
+        files_and_changes_review = files_and_changes_review.filter(
+          ([file]) => file !== filename
+        )
+        reviews_skipped.push(filename)
+      }
+    }
+
     // failed reviews array
     const reviews_failed: string[] = []
     const do_review = async (
@@ -684,7 +707,12 @@ ${comment_chain}
     }
 
     const reviewPromises = []
-    for (const [filename, file_content, , patches] of files_and_changes) {
+    for (const [
+      filename,
+      file_content,
+      ,
+      patches
+    ] of files_and_changes_review) {
       if (options.max_files <= 0 || reviewPromises.length < options.max_files) {
         reviewPromises.push(
           openai_concurrency_limit(async () =>
@@ -709,6 +737,22 @@ ${
 ### Failed to review
 
 * ${reviews_failed.join('\n* ')}
+
+</details>
+`
+    : ''
+}
+
+${
+  reviews_skipped.length > 0
+    ? `<details>
+<summary>Files not reviewed due to simple changes (${
+        reviews_skipped.length
+      })</summary>
+
+### Skipped review
+
+* ${reviews_skipped.join('\n* ')}
 
 </details>
 `

--- a/src/review.ts
+++ b/src/review.ts
@@ -272,12 +272,21 @@ ${hunks.old_hunk}
         // parse the comment to look for complexity classification
         // Format is : [COMPLEXITY]: <COMPLEX or SIMPLE>
         // if the change is complex return true, else false
-        const complexity = summarize_resp
-          .split('[COMPLEXITY]: ')[1]
-          .split('\n')[0]
-        const is_complex = complexity === 'COMPLEX' ? true : false
-        core.info(`filename: ${filename}, complexity: ${complexity}`)
-        return [filename, summarize_resp, is_complex]
+        const complexityRegex = /\[COMPLEXITY\]:\s*(COMPLEX|SIMPLE)/
+        const complexityMatch = summarize_resp.match(complexityRegex)
+
+        if (complexityMatch) {
+          const complexity = complexityMatch[1]
+          const is_complex = complexity === 'COMPLEX' ? true : false
+
+          // remove this line from the comment
+          const summary = summarize_resp.replace(complexityRegex, '').trim()
+          core.info(`filename: ${filename}, complexity: ${complexity}`)
+          return [filename, summary, is_complex]
+        } else {
+          // Handle the case when the [COMPLEXITY] tag is not found
+          return [filename, summarize_resp, true]
+        }
       }
     } catch (error) {
       core.warning(`summarize: error from openai: ${error}`)

--- a/src/review.ts
+++ b/src/review.ts
@@ -438,19 +438,22 @@ ${
 `
 
   if (options.summary_only !== true) {
-    let files_and_changes_review = files_and_changes
-    const reviews_skipped: string[] = []
-    // filter out files that are less complex and remove them from the review
-    // loop through summaries and check the complexity flag
-    for (const [filename, , is_complex] of summaries) {
-      if (!is_complex) {
-        // remove the file from the review
-        files_and_changes_review = files_and_changes_review.filter(
-          ([file]) => file !== filename
-        )
-        reviews_skipped.push(filename)
-      }
-    }
+    const files_and_changes_review = files_and_changes.filter(([filename]) => {
+      const is_complex =
+        summaries.find(
+          ([summaryFilename]) => summaryFilename === filename
+        )?.[2] ?? true
+      return is_complex
+    })
+
+    const reviews_skipped = files_and_changes
+      .filter(
+        ([filename]) =>
+          !files_and_changes_review.some(
+            ([reviewFilename]) => reviewFilename === filename
+          )
+      )
+      .map(([filename]) => filename)
 
     // failed reviews array
     const reviews_failed: string[] = []


### PR DESCRIPTION





<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Release Notes**

- New Feature: Adds a feature to classify the complexity of a diff as either `COMPLEX` or `SIMPLE` based on whether the change is a simple chore or a complex change that needs further review. The code now skips reviewing files that are less complex and removes them from the review. The diff also includes improvements to error handling, logging, and formatting of the review output.

> "Code complexity, oh what a mess,
> But fear not, we've made progress!
> With new features and improvements galore,
> Our codebase is better than ever before!"
<!-- end of auto-generated comment: release notes by openai -->