### PR TITLE
feat(chatgpt): add apiOrg option for ChatGPTAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ To ignore a PR, add the following keyword in the PR description:
 - `OPENAI_API_KEY`: use this to authenticate with OpenAI API. You can get one
   [here](https://platform.openai.com/account/api-keys). Please add this key to
   your GitHub Action secrets.
+- `OPENAI_API_ORG`: (optional) use this to use the specified organisation with OpenAI API if you have multiple. Please add this key to your GitHub Action secrets.
 
 ### Models: `gpt-4` and `gpt-3.5-turbo`
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -25,6 +25,7 @@ export class Bot {
       this.api = new openai.ChatGPTAPI({
         systemMessage: options.system_message,
         apiKey: process.env.OPENAI_API_KEY,
+        apiOrg: process.env.OPENAI_API_ORG ?? null,
         debug: options.debug,
         maxModelTokens: openaiOptions.token_limits.max_tokens,
         maxResponseTokens: openaiOptions.token_limits.response_tokens,


### PR DESCRIPTION
I added apiOrg option for ChatGPTAPI in case you need it to specify which organisation to use when you have multiple one in your OpenAI account

I added a `OPENAI_API_ORG` optionnal env variable.

cc @harjotgill 