### PR TITLE
fix

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6475,10 +6475,11 @@ const codeReview = async (lightBot, heavyBot, options, prompts) => {
     inputs.system_message = options.system_message;
     // get SUMMARIZE_TAG message
     const existing_summarize_cmt = await commenter.find_comment_with_tag(lib_commenter/* SUMMARIZE_TAG */.Rp, context.payload.pull_request.number);
+    let existing_commit_ids_block = '';
     if (existing_summarize_cmt) {
         inputs.raw_summary = commenter.get_raw_summary(existing_summarize_cmt.body);
+        existing_commit_ids_block = getReviewedCommitIdsBlock(existing_summarize_cmt.body);
     }
-    const existing_commit_ids_block = getReviewedCommitIdsBlock(existing_summarize_cmt?.body);
     const allCommitIds = await getAllCommitIds();
     // find highest reviewed commit id
     let highest_reviewed_commit_id = '';

--- a/src/review.ts
+++ b/src/review.ts
@@ -68,12 +68,13 @@ export const codeReview = async (
     SUMMARIZE_TAG,
     context.payload.pull_request.number
   )
+  let existing_commit_ids_block = ''
   if (existing_summarize_cmt) {
     inputs.raw_summary = commenter.get_raw_summary(existing_summarize_cmt.body)
+    existing_commit_ids_block = getReviewedCommitIdsBlock(
+      existing_summarize_cmt.body
+    )
   }
-  const existing_commit_ids_block = getReviewedCommitIdsBlock(
-    existing_summarize_cmt?.body
-  )
 
   const allCommitIds = await getAllCommitIds()
   // find highest reviewed commit id


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Release Notes:**

Bug fix:
- Initialize `existing_commit_ids_block` to an empty string before checking if it exists to prevent potential errors when accessing `existing_summarize_cmt.body`.

> "A bug was found and squashed,
> Now the code is less flawed.
> Errors no longer cause a crash,
> Thanks to this pull request sent abroad."
<!-- end of auto-generated comment: release notes by openai -->