### PR TITLE
remove redundant messages from changesets

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4039,11 +4039,11 @@ class Inputs {
     diff;
     commentChain;
     comment;
-    constructor(systemMessage = '', title = 'no title provided', description = 'no description provided', summary = 'no summary so far', releaseNotes = 'no release notes so far', filename = 'unknown', fileContent = 'file contents cannot be provided', fileDiff = 'file diff cannot be provided', patches = '', diff = 'no diff', commentChain = 'no other comments on this patch', comment = 'no comment provided') {
+    constructor(systemMessage = '', title = 'no title provided', description = 'no description provided', rawSummary = '', releaseNotes = '', filename = '', fileContent = 'file contents cannot be provided', fileDiff = 'file diff cannot be provided', patches = '', diff = 'no diff', commentChain = 'no other comments on this patch', comment = 'no comment provided') {
         this.systemMessage = systemMessage;
         this.title = title;
         this.description = description;
-        this.rawSummary = summary;
+        this.rawSummary = rawSummary;
         this.releaseNotes = releaseNotes;
         this.filename = filename;
         this.fileContent = fileContent;
@@ -6199,7 +6199,6 @@ Your task is to de-deduplicate and group together files with
 related/similar changes into a single changeset. Respond with the updated 
 changesets using the same format as the input. 
 
-Changesets:
 $raw_summary
 `;
     comment = `A comment was made on a GitHub pull request review for a 

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -16,9 +16,9 @@ export class Inputs {
     systemMessage = '',
     title = 'no title provided',
     description = 'no description provided',
-    summary = 'no summary so far',
-    releaseNotes = 'no release notes so far',
-    filename = 'unknown',
+    rawSummary = '',
+    releaseNotes = '',
+    filename = '',
     fileContent = 'file contents cannot be provided',
     fileDiff = 'file diff cannot be provided',
     patches = '',
@@ -29,7 +29,7 @@ export class Inputs {
     this.systemMessage = systemMessage
     this.title = title
     this.description = description
-    this.rawSummary = summary
+    this.rawSummary = rawSummary
     this.releaseNotes = releaseNotes
     this.filename = filename
     this.fileContent = fileContent

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -50,7 +50,6 @@ Your task is to de-deduplicate and group together files with
 related/similar changes into a single changeset. Respond with the updated 
 changesets using the same format as the input. 
 
-Changesets:
 $raw_summary
 `
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

## Release Notes

- Refactor: Remove redundant messages and properties from `Inputs` class constructor in `src/inputs.ts` and `render` method in `src/prompts.ts`.

> "Redundancies be gone, 
> Codebase now sings a new song. 
> Inputs and prompts refined, 
> Quality of code now defined."
<!-- end of auto-generated comment: release notes by openai -->