### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ inputs:
   openai_timeout_ms:
     required: false
     description: 'Timeout for OpenAI API call in millis'
-    default: '120000'
+    default: '180000'
   openai_concurrency_limit:
     required: false
     description: 'How many concurrent API calls to make to OpenAI servers?'


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Release Notes**

- `action.yml`: Increased the default timeout for OpenAI API calls from 120000 to 180000 milliseconds.

> "More time to think, more time to create. Our AI now has room to innovate."
<!-- end of auto-generated comment: release notes by openai -->