### PR TITLE
increase timeout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ inputs:
   openai_timeout_ms:
     required: false
     description: 'Timeout for OpenAI API call in millis'
-    default: '120000'
+    default: '240000'
   openai_concurrency_limit:
     required: false
     description: 'How many concurrent API calls to make to OpenAI servers?'


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

### Release Notes

- `action.yml`: Increased timeout for OpenAI API calls from 120 seconds to 240 seconds.

This pull request improves the reliability of the OpenAI API calls by increasing the timeout duration. This change will ensure that the API calls have enough time to complete, especially when dealing with large amounts of data.

> "OpenAI API calls,  
> Now with more time to stall.  
> No more timeouts,  
> We're breaking down walls!"
<!-- end of auto-generated comment: release notes by openai -->