### PR TITLE
increase timeout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ inputs:
   openai_timeout_ms:
     required: false
     description: 'Timeout for OpenAI API call in millis'
-    default: '240000'
+    default: '360000'
   openai_concurrency_limit:
     required: false
     description: 'How many concurrent API calls to make to OpenAI servers?'


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

### Release Notes
- Chore: Increase timeout for OpenAI API calls from 240000ms to 360000ms.

> "More time to think, more time to create,
> With OpenAI, we'll make something great!"
<!-- end of auto-generated comment: release notes by openai -->