### PR TITLE
Added option to change openai url base

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,11 @@ inputs:
     required: false
     description: 'Disable release notes'
     default: 'false'
+  openai_base_url:
+    required: false
+    description:
+      'The url of the openai api interface.'
+    default: 'https://api.openai.com/v1'
   openai_light_model:
     required: false
     description:

--- a/dist/index.js
+++ b/dist/index.js
@@ -3417,6 +3417,7 @@ class Bot {
         this.options = options;
         if (process.env.OPENAI_API_KEY) {
             this.api = new ChatGPTAPI({
+                apiBaseUrl: options.apiBaseUrl,
                 systemMessage: options.systemMessage,
                 apiKey: process.env.OPENAI_API_KEY,
                 apiOrg: process.env.OPENAI_API_ORG ?? undefined,
@@ -4116,7 +4117,7 @@ __nccwpck_require__.r(__webpack_exports__);
 
 
 async function run() {
-    const options = new _options__WEBPACK_IMPORTED_MODULE_2__/* .Options */ .Ei((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getBooleanInput)('debug'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getBooleanInput)('disable_review'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getBooleanInput)('disable_release_notes'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('max_files'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getBooleanInput)('review_simple_changes'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getBooleanInput)('review_comment_lgtm'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getMultilineInput)('path_filters'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('system_message'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('openai_light_model'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('openai_heavy_model'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('openai_model_temperature'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('openai_retries'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('openai_timeout_ms'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('openai_concurrency_limit'));
+    const options = new _options__WEBPACK_IMPORTED_MODULE_2__/* .Options */ .Ei((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getBooleanInput)('debug'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getBooleanInput)('disable_review'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getBooleanInput)('disable_release_notes'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('max_files'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getBooleanInput)('review_simple_changes'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getBooleanInput)('review_comment_lgtm'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getMultilineInput)('path_filters'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('system_message'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('openai_light_model'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('openai_heavy_model'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('openai_model_temperature'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('openai_retries'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('openai_timeout_ms'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('openai_concurrency_limit'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('openai_base_url'));
     // print options
     options.print();
     const prompts = new _prompts__WEBPACK_IMPORTED_MODULE_5__/* .Prompts */ .j((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('summarize'), (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('summarize_release_notes'));
@@ -6041,7 +6042,8 @@ class Options {
     openaiConcurrencyLimit;
     lightTokenLimits;
     heavyTokenLimits;
-    constructor(debug, disableReview, disableReleaseNotes, maxFiles = '0', reviewSimpleChanges = false, reviewCommentLGTM = false, pathFilters = null, systemMessage = '', openaiLightModel = 'gpt-3.5-turbo', openaiHeavyModel = 'gpt-3.5-turbo', openaiModelTemperature = '0.0', openaiRetries = '3', openaiTimeoutMS = '120000', openaiConcurrencyLimit = '4') {
+    apiBaseUrl;
+    constructor(debug, disableReview, disableReleaseNotes, maxFiles = '0', reviewSimpleChanges = false, reviewCommentLGTM = false, pathFilters = null, systemMessage = '', openaiLightModel = 'gpt-3.5-turbo', openaiHeavyModel = 'gpt-3.5-turbo', openaiModelTemperature = '0.0', openaiRetries = '3', openaiTimeoutMS = '120000', openaiConcurrencyLimit = '4', apiBaseUrl = "https://api.openai.com/v1") {
         this.debug = debug;
         this.disableReview = disableReview;
         this.disableReleaseNotes = disableReleaseNotes;
@@ -6058,6 +6060,7 @@ class Options {
         this.openaiConcurrencyLimit = parseInt(openaiConcurrencyLimit);
         this.lightTokenLimits = new TokenLimits(openaiLightModel);
         this.heavyTokenLimits = new TokenLimits(openaiHeavyModel);
+        this.apiBaseUrl = apiBaseUrl;
     }
     // print all options using core.info
     print() {
@@ -6077,6 +6080,7 @@ class Options {
         (0,core.info)(`openai_concurrency_limit: ${this.openaiConcurrencyLimit}`);
         (0,core.info)(`summary_token_limits: ${this.lightTokenLimits.string()}`);
         (0,core.info)(`review_token_limits: ${this.heavyTokenLimits.string()}`);
+        (0,core.info)(`api_base_url: ${this.apiBaseUrl}`);
     }
     checkPath(path) {
         const ok = this.pathFilters.check(path);

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -26,6 +26,7 @@ export class Bot {
     this.options = options
     if (process.env.OPENAI_API_KEY) {
       this.api = new ChatGPTAPI({
+        apiBaseUrl: options.apiBaseUrl,
         systemMessage: options.systemMessage,
         apiKey: process.env.OPENAI_API_KEY,
         apiOrg: process.env.OPENAI_API_ORG ?? undefined,

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ async function run(): Promise<void> {
     getInput('openai_model_temperature'),
     getInput('openai_retries'),
     getInput('openai_timeout_ms'),
-    getInput('openai_concurrency_limit')
+    getInput('openai_concurrency_limit'),
     getInput('openai_base_url')
   )
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ async function run(): Promise<void> {
     getInput('openai_retries'),
     getInput('openai_timeout_ms'),
     getInput('openai_concurrency_limit')
+    getInput('openai_base_url')
   )
 
   // print options

--- a/src/options.ts
+++ b/src/options.ts
@@ -19,6 +19,7 @@ export class Options {
   openaiConcurrencyLimit: number
   lightTokenLimits: TokenLimits
   heavyTokenLimits: TokenLimits
+  apiBaseUrl: string
 
   constructor(
     debug: boolean,
@@ -34,7 +35,8 @@ export class Options {
     openaiModelTemperature = '0.0',
     openaiRetries = '3',
     openaiTimeoutMS = '120000',
-    openaiConcurrencyLimit = '4'
+    openaiConcurrencyLimit = '4',
+    apiBaseUrl = "https://api.openai.com/v1"
   ) {
     this.debug = debug
     this.disableReview = disableReview
@@ -52,6 +54,7 @@ export class Options {
     this.openaiConcurrencyLimit = parseInt(openaiConcurrencyLimit)
     this.lightTokenLimits = new TokenLimits(openaiLightModel)
     this.heavyTokenLimits = new TokenLimits(openaiHeavyModel)
+    this.apiBaseUrl = apiBaseUrl
   }
 
   // print all options using core.info
@@ -72,6 +75,7 @@ export class Options {
     info(`openai_concurrency_limit: ${this.openaiConcurrencyLimit}`)
     info(`summary_token_limits: ${this.lightTokenLimits.string()}`)
     info(`review_token_limits: ${this.heavyTokenLimits.string()}`)
+    info(`api_base_url: ${this.apiBaseUrl}`)
   }
 
   checkPath(path: string): boolean {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

### Release Notes
New Feature: Added optional input parameter and option `apiBaseUrl` to change the URL of the OpenAI API interface. This allows users to use a different API endpoint or a local instance of the API.

> "With new options to choose,  
> The OpenAI API is yours to use.  
> Change the URL with ease,  
> And enjoy the code as you please."
<!-- end of auto-generated comment: release notes by openai -->