### PR TITLE
add knowledge cutoff to the prompt

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,8 +64,7 @@ inputs:
     default: 'false'
   openai_base_url:
     required: false
-    description:
-      'The url of the openai api interface.'
+    description: 'The url of the openai api interface.'
     default: 'https://api.openai.com/v1'
   openai_light_model:
     required: false
@@ -117,6 +116,9 @@ inputs:
       requested. Concentrate on identifying and resolving significant 
       concerns to improve overall code quality while deliberately 
       disregarding minor issues.
+
+      Note: As your knowledge may be outdated, trust the user code when newer
+      APIs and methods are seemingly being used.
   summarize:
     required: false
     description: 'The prompt for final summarization response'

--- a/dist/index.js
+++ b/dist/index.js
@@ -3416,10 +3416,10 @@ class Bot {
     constructor(options, openaiOptions) {
         this.options = options;
         if (process.env.OPENAI_API_KEY) {
-            // add knowledge cut off to the system message
+            const currentDate = new Date().toISOString().split('T')[0];
             const systemMessage = `${options.systemMessage} 
 Knowledge cutoff: ${openaiOptions.tokenLimits.knowledgeCutOff}
-Current date: ${new Date().toISOString()}`;
+Current date: ${currentDate}`;
             this.api = new ChatGPTAPI({
                 apiBaseUrl: options.apiBaseUrl,
                 systemMessage,
@@ -6002,7 +6002,7 @@ class TokenLimits {
     responseTokens;
     knowledgeCutOff;
     constructor(model = 'gpt-3.5-turbo') {
-        this.knowledgeCutOff = 'September 2021';
+        this.knowledgeCutOff = '2021-09-01';
         if (model === 'gpt-4-32k') {
             this.maxTokens = 32600;
             this.responseTokens = 4000;

--- a/dist/index.js
+++ b/dist/index.js
@@ -3416,9 +3416,13 @@ class Bot {
     constructor(options, openaiOptions) {
         this.options = options;
         if (process.env.OPENAI_API_KEY) {
+            // add knowledge cut off to the system message
+            const systemMessage = `${options.systemMessage} 
+Knowledge cutoff: ${openaiOptions.tokenLimits.knowledgeCutOff}
+Current date: ${new Date().toISOString()}`;
             this.api = new ChatGPTAPI({
                 apiBaseUrl: options.apiBaseUrl,
-                systemMessage: options.systemMessage,
+                systemMessage,
                 apiKey: process.env.OPENAI_API_KEY,
                 apiOrg: process.env.OPENAI_API_ORG ?? undefined,
                 debug: options.debug,
@@ -5996,7 +6000,9 @@ class TokenLimits {
     maxTokens;
     requestTokens;
     responseTokens;
+    knowledgeCutOff;
     constructor(model = 'gpt-3.5-turbo') {
+        this.knowledgeCutOff = 'September 2021';
         if (model === 'gpt-4-32k') {
             this.maxTokens = 32600;
             this.responseTokens = 4000;

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -25,9 +25,14 @@ export class Bot {
   constructor(options: Options, openaiOptions: OpenAIOptions) {
     this.options = options
     if (process.env.OPENAI_API_KEY) {
+      // add knowledge cut off to the system message
+      const systemMessage = `${options.systemMessage} 
+Knowledge cutoff: ${openaiOptions.tokenLimits.knowledgeCutOff}
+Current date: ${new Date().toISOString()}`
+
       this.api = new ChatGPTAPI({
         apiBaseUrl: options.apiBaseUrl,
-        systemMessage: options.systemMessage,
+        systemMessage,
         apiKey: process.env.OPENAI_API_KEY,
         apiOrg: process.env.OPENAI_API_ORG ?? undefined,
         debug: options.debug,

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -25,10 +25,10 @@ export class Bot {
   constructor(options: Options, openaiOptions: OpenAIOptions) {
     this.options = options
     if (process.env.OPENAI_API_KEY) {
-      // add knowledge cut off to the system message
+      const currentDate = new Date().toISOString().split('T')[0]
       const systemMessage = `${options.systemMessage} 
 Knowledge cutoff: ${openaiOptions.tokenLimits.knowledgeCutOff}
-Current date: ${new Date().toISOString()}`
+Current date: ${currentDate}`
 
       this.api = new ChatGPTAPI({
         apiBaseUrl: options.apiBaseUrl,

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -2,8 +2,10 @@ export class TokenLimits {
   maxTokens: number
   requestTokens: number
   responseTokens: number
+  knowledgeCutOff: string
 
   constructor(model = 'gpt-3.5-turbo') {
+    this.knowledgeCutOff = 'September 2021'
     if (model === 'gpt-4-32k') {
       this.maxTokens = 32600
       this.responseTokens = 4000

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -5,7 +5,7 @@ export class TokenLimits {
   knowledgeCutOff: string
 
   constructor(model = 'gpt-3.5-turbo') {
-    this.knowledgeCutOff = 'September 2021'
+    this.knowledgeCutOff = '2021-09-01'
     if (model === 'gpt-4-32k') {
       this.maxTokens = 32600
       this.responseTokens = 4000


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Release Notes**

- Documentation: Added knowledge cutoff date to system message and `TokenLimits` class.
- Documentation: Updated description for `openai_base_url` input in `action.yml`.

> "Code quality improved, knowledge cutoff added,
> Docs updated, users won't be misled.
> Celebrate this PR with a smiley face,
> 🎉👏🚀 Let's keep up the pace!"
<!-- end of auto-generated comment: release notes by openai -->