### PR TITLE
Added support for gpt-4 128k

### DIFF
--- a/src/limits.ts
+++ b/src/limits.ts
@@ -6,18 +6,28 @@ export class TokenLimits {
 
   constructor(model = 'gpt-3.5-turbo') {
     this.knowledgeCutOff = '2021-09-01'
-    if (model === 'gpt-4-32k') {
-      this.maxTokens = 32600
-      this.responseTokens = 4000
-    } else if (model === 'gpt-3.5-turbo-16k') {
-      this.maxTokens = 16300
-      this.responseTokens = 3000
-    } else if (model === 'gpt-4') {
-      this.maxTokens = 8000
-      this.responseTokens = 2000
-    } else {
-      this.maxTokens = 4000
-      this.responseTokens = 1000
+    switch (model) {
+      case 'gpt-4-1106-preview':
+        this.maxTokens = 128000
+        this.responseTokens = 4000
+        this.knowledgeCutOff = '2023-04-01'
+        break
+      case 'gpt-4':
+        this.maxTokens = 8000
+        this.responseTokens = 2000
+        break
+      case 'gpt-4-32k':
+        this.maxTokens = 32600
+        this.responseTokens = 4000
+        break
+      case 'gpt-3.5-turbo-16k':
+        this.maxTokens = 16300
+        this.responseTokens = 3000
+        break
+      default:
+        this.maxTokens = 4000
+        this.responseTokens = 1000
+        break
     }
     // provide some margin for the request tokens
     this.requestTokens = this.maxTokens - this.responseTokens - 100


### PR DESCRIPTION
With yesterday's release GPT-4 128k is available in the API. Updated limits (but left default) with the new values from https://help.openai.com/en/articles/8555510-gpt-4-turbo
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added support for the new GPT-4 128k model in the `TokenLimits` class. This update allows users to utilize the increased token limit and response tokens of the GPT-4 model, enhancing the capabilities of their AI applications. Please note that the `knowledgeCutOff` value has also been updated for this model.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->