### PR TITLE
Use gpt-4-turbo-preview model 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   review_simple_changes:
     required: false
     description: 'Review even when the changes are simple'
-    default: 'true'
+    default: 'false'
   review_comment_lgtm:
     required: false
     description: 'Leave comments even if the patch is LGTM'
@@ -156,7 +156,7 @@ inputs:
   openai_heavy_model:
     required: false
     description: 'Model to use for complex tasks such as code reviews.'
-    default: 'gpt-3.5-turbo'
+    default: 'gpt-4-turbo-preview'
   openai_model_temperature:
     required: false
     description: 'Temperature for GPT model'

--- a/action.yml
+++ b/action.yml
@@ -134,6 +134,8 @@ inputs:
       !**/*.min.js.css
       !**/*.tfstate
       !**/*.tfstate.backup
+      !**/vault.yml
+      !**/vault.yaml
   disable_review:
     required: false
     description: 'Only provide the summary and skip the code review.'

--- a/action.yml
+++ b/action.yml
@@ -101,8 +101,6 @@ inputs:
       !**/*.pb.go
       !**/*.lock
       !**/*.ttf
-      !**/*.yaml
-      !**/*.yml
       !**/*.cfg
       !**/*.toml
       !**/*.ini

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   review_simple_changes:
     required: false
     description: 'Review even when the changes are simple'
-    default: 'false'
+    default: 'true'
   review_comment_lgtm:
     required: false
     description: 'Leave comments even if the patch is LGTM'

--- a/action.yml
+++ b/action.yml
@@ -210,9 +210,6 @@ inputs:
         specific files within 80 words.
       - **Changes**: A markdown table of files and their summaries. Group files 
         with similar changes together into a single row to save space.
-      - **Poem**: Below the changes, include a whimsical, short poem written by 
-        a rabbit to celebrate the changes. Format the poem as a quote using 
-        the ">" symbol and feel free to use emojis where relevant.
 
       Avoid additional commentary as this summary will be added as a comment on the 
       GitHub pull request. Use the titles "Walkthrough" and "Changes" and they must be H2.

--- a/action.yml
+++ b/action.yml
@@ -154,7 +154,7 @@ inputs:
   openai_heavy_model:
     required: false
     description: 'Model to use for complex tasks such as code reviews.'
-    default: 'gpt-4'
+    default: 'gpt-3.5-turbo'
   openai_model_temperature:
     required: false
     description: 'Temperature for GPT model'

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -6,19 +6,30 @@ export class TokenLimits {
 
   constructor(model = 'gpt-3.5-turbo') {
     this.knowledgeCutOff = '2021-09-01'
-    if (model === 'gpt-4-32k') {
-      this.maxTokens = 32600
-      this.responseTokens = 4000
-    } else if (model === 'gpt-3.5-turbo-16k') {
-      this.maxTokens = 16300
-      this.responseTokens = 3000
-    } else if (model === 'gpt-4') {
-      this.maxTokens = 8000
-      this.responseTokens = 2000
-    } else {
-      this.maxTokens = 4000
-      this.responseTokens = 1000
+    switch (model) {
+      case 'gpt-4-32k':
+        this.maxTokens = 32600
+        this.responseTokens = 4000
+        break
+      case 'gpt-3.5-turbo-16k':
+        this.maxTokens = 16300
+        this.responseTokens = 3000
+        break
+      case 'gpt-4':
+        this.maxTokens = 8000
+        this.responseTokens = 2000
+        break
+      case 'gpt-4-turbo-preview':
+        this.maxTokens = 128000
+        this.responseTokens = 4000
+        this.knowledgeCutOff = '2023-12-01'
+        break
+      default:
+        this.maxTokens = 4000
+        this.responseTokens = 1000
+        break
     }
+
     // provide some margin for the request tokens
     this.requestTokens = this.maxTokens - this.responseTokens - 100
   }


### PR DESCRIPTION
Support gpt-4-turbo-preview as heavy model. This is cheaper than gpt-4 and provides a huge context.
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

---
- New Feature: Added support for the `gpt-4-turbo-preview` model as a heavy model, replacing `gpt-4`. This allows users to utilize the latest AI model for their tasks.
- Refactor: Improved code readability and maintainability by replacing the if-else chain in `TokenLimits` constructor with a switch-case.
- Chore: Updated file exclusions and default values for model selection to align with the new changes.
---
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated token limits for enhanced performance, including support for the 'gpt-4-turbo-preview' model with increased limits and an updated knowledge cutoff date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->